### PR TITLE
feat(marketplace): add off-chain fiat payments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 cache/
 out/
 
+# Audit and x-ray
+audit/
+x-ray/
+
 # Ignores all broadcast logs
 /broadcast
 
@@ -13,6 +17,9 @@ docs/
 
 # IDE files
 .vscode
+
+# Obsidian files
+.obsidian
 
 # Wake files
 .wake

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ out/
 # Audit and x-ray
 audit/
 x-ray/
+AUDIT_PREP.md
+VULNS.md
 
 # Ignores all broadcast logs
 /broadcast

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,9 +6,6 @@ remappings = [
     '@ticket/=src/',
     '@ticket-script/=script/',
     '@ticket-test/=test/',
-    '@ticket-errors/=src/libs/errors/',
-    '@ticket-logs/=src/libs/logs/',
-    '@ticket-storage/=src/libs/storage/',
     "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/",
     "@openzeppelin/contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/",
     "@tokenbound/=lib/contracts/src/",
@@ -39,6 +36,7 @@ avalanche = "${AVALANCHE_MAINNET_URL}"
 avalanche-fuji = "${AVALANCHE_FUJI_URL}"
 mantle = "${MANTLE_MAINNET_URL}"
 mantle-sepolia = "${MANTLE_SEPOLIA_URL}"
+arc-testnet = "${ARC_TESTNET_URL}"
 
 [etherscan]
 mainnet = { key = "${ETHERSCAN_API_KEY}" }
@@ -51,3 +49,4 @@ arbitrum-one = { key = "${ETHERSCAN_API_KEY}" }
 arbitrum-sepolia = { key = "${ETHERSCAN_API_KEY}" }
 avalanche = { key = "verifyContract", url = "${AVALANCHE_VERIFIER_URL}" }
 avalanche-fuji = { key = "verifyContract", url = "${AVALANCHE_FUJI_VERIFIER_URL}" }
+arc-testnet = { key = "123", url = "${ARC_TESTNET_VERIFIER_URL}" }

--- a/script/helpers/AddressesAndFees.sol
+++ b/script/helpers/AddressesAndFees.sol
@@ -5,43 +5,46 @@ import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 import {FeeType} from "@ticket/libs/MarketplaceLib.sol";
 
 library AddressesAndFees {
-    function _byChainId(uint256 _chainId) internal returns (uint8[] memory feeTypes_, address[] memory addresses_) {
+    function byChainId(uint256 _chainId) internal returns (uint8[] memory feeTypes_, address[] memory addresses_) {
         if (_chainId == 1) {
-            addresses_ = _getEthereumAddresses();
-            feeTypes_ = _getEthereumFeeTypes();
+            feeTypes_ = getEthereumFeeTypes();
+            addresses_ = getEthereumAddresses();
+        } else if (_chainId == 5042002) {
+            feeTypes_ = getArcTestnetFeeTypes();
+            addresses_ = getArcTestnetAddresses();
         } else if (_chainId == 8453) {
-            addresses_ = _getBaseAddresses();
-            feeTypes_ = _getBaseFeeTypes();
+            feeTypes_ = getBaseFeeTypes();
+            addresses_ = getBaseAddresses();
         } else if (_chainId == 43114) {
-            addresses_ = _getAvalancheAddresses();
-            feeTypes_ = _getAvalancheFeeTypes();
+            feeTypes_ = getAvalancheFeeTypes();
+            addresses_ = getAvalancheAddresses();
         } else if (_chainId == 42161) {
-            addresses_ = _getArbitrumOneAddresses();
-            feeTypes_ = _getArbitrumOneFeeTypes();
+            feeTypes_ = getArbitrumOneFeeTypes();
+            addresses_ = getArbitrumOneAddresses();
         } else if (_chainId == 1135) {
-            addresses_ = _getLiskAddresses();
-            feeTypes_ = _getLiskFeeTypes();
+            feeTypes_ = getLiskFeeTypes();
+            addresses_ = getLiskAddresses();
         } else if (_chainId == 11155111) {
-            addresses_ = _getEthereumSepoliaAddresses();
-            feeTypes_ = _getEthereumSepoliaFeeTypes();
+            feeTypes_ = getEthereumSepoliaFeeTypes();
+            addresses_ = getEthereumSepoliaAddresses();
         } else if (_chainId == 84532) {
-            addresses_ = _getBaseSepoliaAddresses();
-            feeTypes_ = _getBaseSepoliaFeeTypes();
+            feeTypes_ = getBaseSepoliaFeeTypes();
+            addresses_ = getBaseSepoliaAddresses();
         } else if (_chainId == 43113) {
-            addresses_ = _getAvalancheFujiAddresses();
-            feeTypes_ = _getAvalancheFujiFeeTypes();
+            feeTypes_ = getAvalancheFujiFeeTypes();
+            addresses_ = getAvalancheFujiAddresses();
         } else if (_chainId == 421614) {
-            addresses_ = _getArbitrumSepoliaAddresses();
-            feeTypes_ = _getArbitrumSepoliaFeeTypes();
+            feeTypes_ = getArbitrumSepoliaFeeTypes();
+            addresses_ = getArbitrumSepoliaAddresses();
         } else if (_chainId == 4202) {
-            addresses_ = _getLiskSepoliaAddresses();
-            feeTypes_ = _getLiskSepoliaFeeTypes();
+            feeTypes_ = getLiskSepoliaFeeTypes();
+            addresses_ = getLiskSepoliaAddresses();
         } else if (_chainId == 5003) {
-            addresses_ = _getMantleSepoliaAddresses();
-            feeTypes_ = _getMantleSepoliaFeeTypes();
+            feeTypes_ = getMantleSepoliaFeeTypes();
+            addresses_ = getMantleSepoliaAddresses();
         } else if (_chainId == 31337) {
-            addresses_ = _getMockAddresses();
-            feeTypes_ = _getMockFeeTypes();
+            feeTypes_ = getMockFeeTypes();
+            addresses_ = getMockAddresses();
         } else {
             revert("Chain not supported");
         }
@@ -51,16 +54,16 @@ library AddressesAndFees {
     //                             MAINNET ADDRESSES
     //////////////////////////////////////////////////////////////////////////*//
 
-    function _getEthereumFeeTypes() internal pure returns (uint8[] memory feeType_) {
+    function getEthereumFeeTypes() internal pure returns (uint8[] memory feeType_) {
         feeType_ = new uint8[](5);
         feeType_[0] = uint8(FeeType.USDC);
         feeType_[1] = uint8(FeeType.USDT);
         feeType_[2] = uint8(FeeType.GHO);
         feeType_[3] = uint8(FeeType.LINK);
-        feeType_[4] = uint8(FeeType.WETH);
+        feeType_[4] = uint8(FeeType.WNATIVE);
     }
 
-    function _getEthereumAddresses() internal pure returns (address[] memory addresses_) {
+    function getEthereumAddresses() internal pure returns (address[] memory addresses_) {
         addresses_ = new address[](5);
         addresses_[0] = ETH_USDC;
         addresses_[1] = ETH_USDT;
@@ -69,17 +72,31 @@ library AddressesAndFees {
         addresses_[4] = ETH_WETH;
     }
 
-    function _getBaseFeeTypes() internal pure returns (uint8[] memory feeType_) {
+    function getArcTestnetFeeTypes() internal pure returns (uint8[] memory feeType_) {
+        feeType_ = new uint8[](3);
+        feeType_[0] = uint8(FeeType.USDC);
+        feeType_[1] = uint8(FeeType.EURC);
+        feeType_[2] = uint8(FeeType.LINK);
+    }
+
+    function getArcTestnetAddresses() internal pure returns (address[] memory addresses_) {
+        addresses_ = new address[](3);
+        addresses_[0] = ARC_TESTNET_USDC;
+        addresses_[1] = ARC_TESTNET_EURC;
+        addresses_[2] = ARC_TESTNET_LINK;
+    }
+
+    function getBaseFeeTypes() internal pure returns (uint8[] memory feeType_) {
         feeType_ = new uint8[](6);
         feeType_[0] = uint8(FeeType.USDC);
         feeType_[1] = uint8(FeeType.USDT);
         feeType_[2] = uint8(FeeType.GHO);
         feeType_[3] = uint8(FeeType.LINK);
-        feeType_[4] = uint8(FeeType.WETH);
+        feeType_[4] = uint8(FeeType.WNATIVE);
         feeType_[5] = uint8(FeeType.EURC);
     }
 
-    function _getBaseAddresses() internal pure returns (address[] memory addresses_) {
+    function getBaseAddresses() internal pure returns (address[] memory addresses_) {
         addresses_ = new address[](6);
         addresses_[0] = BASE_USDC;
         addresses_[1] = BASE_USDT;
@@ -89,15 +106,15 @@ library AddressesAndFees {
         addresses_[5] = BASE_EURC;
     }
 
-    function _getAvalancheFeeTypes() internal pure returns (uint8[] memory feeType_) {
+    function getAvalancheFeeTypes() internal pure returns (uint8[] memory feeType_) {
         feeType_ = new uint8[](4);
         feeType_[0] = uint8(FeeType.USDC);
         feeType_[1] = uint8(FeeType.GHO);
         feeType_[2] = uint8(FeeType.LINK);
-        feeType_[3] = uint8(FeeType.WETH);
+        feeType_[3] = uint8(FeeType.WNATIVE);
     }
 
-    function _getAvalancheAddresses() internal pure returns (address[] memory addresses_) {
+    function getAvalancheAddresses() internal pure returns (address[] memory addresses_) {
         addresses_ = new address[](4);
         addresses_[0] = AVALANCHE_USDC;
         addresses_[1] = AVALANCHE_GHO;
@@ -105,15 +122,15 @@ library AddressesAndFees {
         addresses_[3] = AVALANCHE_WAVAX;
     }
 
-    function _getArbitrumOneFeeTypes() internal pure returns (uint8[] memory feeType_) {
+    function getArbitrumOneFeeTypes() internal pure returns (uint8[] memory feeType_) {
         feeType_ = new uint8[](4);
         feeType_[0] = uint8(FeeType.USDC);
         feeType_[1] = uint8(FeeType.GHO);
         feeType_[2] = uint8(FeeType.LINK);
-        feeType_[3] = uint8(FeeType.WETH);
+        feeType_[3] = uint8(FeeType.WNATIVE);
     }
 
-    function _getArbitrumOneAddresses() internal pure returns (address[] memory addresses_) {
+    function getArbitrumOneAddresses() internal pure returns (address[] memory addresses_) {
         addresses_ = new address[](4);
         addresses_[0] = ARBITRUM_ONE_USDC;
         addresses_[1] = ARBITRUM_ONE_GHO;
@@ -121,7 +138,7 @@ library AddressesAndFees {
         addresses_[3] = ARBITRUM_ONE_WETH;
     }
 
-    function _getLiskFeeTypes() internal pure returns (uint8[] memory feeType_) {
+    function getLiskFeeTypes() internal pure returns (uint8[] memory feeType_) {
         feeType_ = new uint8[](6);
         feeType_[0] = uint8(FeeType.USDC);
         feeType_[1] = uint8(FeeType.USDT);
@@ -131,7 +148,7 @@ library AddressesAndFees {
         feeType_[5] = uint8(FeeType.USDT0);
     }
 
-    function _getLiskAddresses() internal pure returns (address[] memory addresses_) {
+    function getLiskAddresses() internal pure returns (address[] memory addresses_) {
         addresses_ = new address[](6);
         addresses_[0] = LISK_USDC;
         addresses_[1] = LISK_USDT;
@@ -145,30 +162,30 @@ library AddressesAndFees {
     //                             TESTNET ADDRESSES
     //////////////////////////////////////////////////////////////////////////*//
 
-    function _getEthereumSepoliaFeeTypes() internal pure returns (uint8[] memory feeType_) {
+    function getEthereumSepoliaFeeTypes() internal pure returns (uint8[] memory feeType_) {
         feeType_ = new uint8[](3);
         feeType_[0] = uint8(FeeType.USDC);
         feeType_[1] = uint8(FeeType.LINK);
-        feeType_[2] = uint8(FeeType.WETH);
+        feeType_[2] = uint8(FeeType.WNATIVE);
     }
 
-    function _getEthereumSepoliaAddresses() internal pure returns (address[] memory addresses_) {
+    function getEthereumSepoliaAddresses() internal pure returns (address[] memory addresses_) {
         addresses_ = new address[](3);
         addresses_[0] = ETH_SEPOLIA_USDC;
         addresses_[1] = ETH_SEPOLIA_LINK;
         addresses_[2] = ETH_SEPOLIA_WETH;
     }
 
-    function _getBaseSepoliaFeeTypes() internal pure returns (uint8[] memory feeType_) {
+    function getBaseSepoliaFeeTypes() internal pure returns (uint8[] memory feeType_) {
         feeType_ = new uint8[](5);
         feeType_[0] = uint8(FeeType.USDC);
         feeType_[1] = uint8(FeeType.USDT);
         feeType_[2] = uint8(FeeType.LINK);
-        feeType_[3] = uint8(FeeType.WETH);
+        feeType_[3] = uint8(FeeType.WNATIVE);
         feeType_[4] = uint8(FeeType.EURC);
     }
 
-    function _getBaseSepoliaAddresses() internal pure returns (address[] memory addresses_) {
+    function getBaseSepoliaAddresses() internal pure returns (address[] memory addresses_) {
         addresses_ = new address[](5);
         addresses_[0] = BASE_SEPOLIA_USDC;
         addresses_[1] = BASE_SEPOLIA_USDT;
@@ -177,43 +194,43 @@ library AddressesAndFees {
         addresses_[4] = BASE_SEPOLIA_EURC;
     }
 
-    function _getAvalancheFujiFeeTypes() internal pure returns (uint8[] memory feeType_) {
+    function getAvalancheFujiFeeTypes() internal pure returns (uint8[] memory feeType_) {
         feeType_ = new uint8[](3);
         feeType_[0] = uint8(FeeType.USDC);
         feeType_[1] = uint8(FeeType.LINK);
-        feeType_[2] = uint8(FeeType.WETH);
+        feeType_[2] = uint8(FeeType.WNATIVE);
     }
 
-    function _getAvalancheFujiAddresses() internal pure returns (address[] memory addresses_) {
+    function getAvalancheFujiAddresses() internal pure returns (address[] memory addresses_) {
         addresses_ = new address[](3);
         addresses_[0] = AVALANCHE_FUJI_USDC;
         addresses_[1] = AVALANCHE_FUJI_LINK;
         addresses_[2] = AVALANCHE_FUJI_WAVAX;
     }
 
-    function _getArbitrumSepoliaFeeTypes() internal pure returns (uint8[] memory feeType_) {
+    function getArbitrumSepoliaFeeTypes() internal pure returns (uint8[] memory feeType_) {
         feeType_ = new uint8[](3);
         feeType_[0] = uint8(FeeType.USDC);
         feeType_[1] = uint8(FeeType.LINK);
-        feeType_[2] = uint8(FeeType.WETH);
+        feeType_[2] = uint8(FeeType.WNATIVE);
     }
 
-    function _getArbitrumSepoliaAddresses() internal pure returns (address[] memory addresses_) {
+    function getArbitrumSepoliaAddresses() internal pure returns (address[] memory addresses_) {
         addresses_ = new address[](3);
         addresses_[0] = ARBITRUM_SEPOLIA_USDC;
         addresses_[1] = ARBITRUM_SEPOLIA_LINK;
         addresses_[2] = ARBITRUM_SEPOLIA_WETH;
     }
 
-    function _getLiskSepoliaFeeTypes() internal pure returns (uint8[] memory feeType_) {
+    function getLiskSepoliaFeeTypes() internal pure returns (uint8[] memory feeType_) {
         feeType_ = new uint8[](4);
         feeType_[0] = uint8(FeeType.USDC);
         feeType_[1] = uint8(FeeType.LINK);
-        feeType_[2] = uint8(FeeType.WETH);
+        feeType_[2] = uint8(FeeType.WNATIVE);
         feeType_[3] = uint8(FeeType.LSK);
     }
 
-    function _getLiskSepoliaAddresses() internal pure returns (address[] memory addresses_) {
+    function getLiskSepoliaAddresses() internal pure returns (address[] memory addresses_) {
         addresses_ = new address[](4);
         addresses_[0] = LISK_SEPOLIA_USDC;
         addresses_[1] = LISK_SEPOLIA_LINK;
@@ -221,15 +238,15 @@ library AddressesAndFees {
         addresses_[3] = LISK_SEPOLIA_LSK;
     }
 
-    function _getMantleSepoliaFeeTypes() internal pure returns (uint8[] memory feeType_) {
+    function getMantleSepoliaFeeTypes() internal pure returns (uint8[] memory feeType_) {
         feeType_ = new uint8[](4);
         feeType_[0] = uint8(FeeType.USDC);
         feeType_[1] = uint8(FeeType.USDT);
         feeType_[2] = uint8(FeeType.LINK);
-        feeType_[3] = uint8(FeeType.WETH);
+        feeType_[3] = uint8(FeeType.WNATIVE);
     }
 
-    function _getMantleSepoliaAddresses() internal pure returns (address[] memory addresses_) {
+    function getMantleSepoliaAddresses() internal pure returns (address[] memory addresses_) {
         addresses_ = new address[](4);
         addresses_[0] = MANTLE_SEPOLIA_USDC;
         addresses_[1] = MANTLE_SEPOLIA_USDT;
@@ -237,9 +254,9 @@ library AddressesAndFees {
         addresses_[3] = MANTLE_SEPOLIA_WMNT;
     }
 
-    function _getMockFeeTypes() internal pure returns (uint8[] memory feeType_) {
+    function getMockFeeTypes() internal pure returns (uint8[] memory feeType_) {
         feeType_ = new uint8[](8);
-        feeType_[0] = uint8(FeeType.WETH);
+        feeType_[0] = uint8(FeeType.WNATIVE);
         feeType_[1] = uint8(FeeType.USDT);
         feeType_[2] = uint8(FeeType.USDC);
         feeType_[3] = uint8(FeeType.EURC);
@@ -249,7 +266,7 @@ library AddressesAndFees {
         feeType_[7] = uint8(FeeType.LSK);
     }
 
-    function _getMockAddresses() internal returns (address[] memory addresses_) {
+    function getMockAddresses() internal returns (address[] memory addresses_) {
         addresses_ = new address[](8);
         addresses_[0] = address(new ERC20Mock());
         addresses_[1] = address(new ERC20Mock());
@@ -279,6 +296,14 @@ address constant ETH_WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 address constant ETH_SEPOLIA_USDC = 0xf661043d9Bc1ef2169Ef90ad3b2285Cf8Bfc0AE2;
 address constant ETH_SEPOLIA_LINK = 0x779877A7B0D9E8603169DdbD7836e478b4624789;
 address constant ETH_SEPOLIA_WETH = 0x097D90c9d3E0B50Ca60e1ae45F6A81010f9FB534;
+
+//*//////////////////////////////////////////////////////////////////////////
+//                           ARC TESTNET ADDRESSES
+//////////////////////////////////////////////////////////////////////////*//
+
+address constant ARC_TESTNET_USDC = 0x3600000000000000000000000000000000000000;
+address constant ARC_TESTNET_EURC = 0x89B50855Aa3bE2F677cD6303Cec089B5F319D72a;
+address constant ARC_TESTNET_LINK = 0x3F1f176e347235858DD6Db905DDBA09Eaf25478a;
 
 //*//////////////////////////////////////////////////////////////////////////
 //                               BASE ADDRESSES

--- a/script/helpers/DeployHostItTicketsHelper.sol
+++ b/script/helpers/DeployHostItTicketsHelper.sol
@@ -34,21 +34,21 @@ abstract contract DeployHostItTicketsHelper is GetSelectors, Context {
     function _getDiamondCutFacet() internal returns (address) {
         return
         // DIAMOND_CUT_FACET.code.length == 0 ?
-        address(new DiamondCutFacet{salt: DIAMOND_CUT_SALT}());
+        address(new DiamondCutFacet());
         // : DIAMOND_CUT_FACET;
     }
 
     function _getDiamondLoupeFacet() internal returns (address) {
         return
         // DIAMOND_LOUPE_FACET.code.length == 0 ?
-        address(new DiamondLoupeFacet{salt: DIAMOND_LOUPE_SALT}());
+        address(new DiamondLoupeFacet());
         // : DIAMOND_LOUPE_FACET;
     }
 
     function _getOwnableFacet() internal returns (address) {
         return
         // OWNABLE_FACET.code.length == 0 ?
-        address(new OwnableFacet{salt: OWNABLE_SALT}());
+        address(new OwnableFacet());
         // : OWNABLE_FACET;
     }
 
@@ -75,7 +75,7 @@ abstract contract DeployHostItTicketsHelper is GetSelectors, Context {
     function _getDiamondInit() internal returns (address) {
         return
         // DIAMOND_INIT.code.length == 0 ?
-        address(new DiamondInit{salt: DIAMOND_INIT_SALT}());
+        address(new DiamondInit());
         //  : DIAMOND_INIT;
     }
 
@@ -141,7 +141,7 @@ abstract contract DeployHostItTicketsHelper is GetSelectors, Context {
         initAddresses[1] = _getHostItInit();
 
         initCalldatas[0] = abi.encodeWithSignature("init(address)", _msgSender());
-        (uint8[] memory feeTypes, address[] memory addresses) = AddressesAndFees._byChainId(block.chainid);
+        (uint8[] memory feeTypes, address[] memory addresses) = AddressesAndFees.byChainId(block.chainid);
         initCalldatas[1] = abi.encodeWithSignature(
             "initHostIt(address,address,uint8[],address[])", _msgSender(), _getTicketImpl(), feeTypes, addresses
         );
@@ -152,7 +152,7 @@ abstract contract DeployHostItTicketsHelper is GetSelectors, Context {
     function _getHostItTickets() internal returns (address ticket_) {
         ticket_ =
         // HOST_IT_TICKETS.code.length == 0 ?
-        address(new HostItTickets{salt: HOST_IT_SALT}(tx.origin));
+        address(new HostItTickets(tx.origin));
         // : HOST_IT_TICKETS;
         HostItTickets(payable(ticket_)).initialize(_createFacetCuts(), _getMultiInit(), _getMultiInitCalldata());
     }

--- a/src/HostItTickets.sol
+++ b/src/HostItTickets.sol
@@ -34,7 +34,10 @@ import {AccessControlLib} from "@lattice/access/libraries/AccessControlLib.sol";
 ⠻⠿⠿⠿⠿⠿⠿⠿⠿⠏⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠻⠿⠿⠿⠿⠿⠿⠿⠿⠿⠃
 */
 
-bytes32 constant INITIALIZER_ROLE = 0x00;
+error DirectETHTransferNotAllowed();
+
+// keccak256("host.it.tickets.initializer")
+bytes32 constant INITIALIZER_ROLE = 0x8bee2586c5e3fefa3b170e4d771ec5051c21576e1f631a6fb7cebb1c8696086a;
 
 /// @title HostIt Tickets
 /// @notice Implements ERC-2535 Diamond proxy pattern, allowing dynamic addition, replacement, and removal of facets
@@ -55,7 +58,7 @@ contract HostItTickets is Diamond {
 
     receive() external payable override {
         assembly ("memory-safe") {
-            mstore(0x00, 0xb12d13eb) // `ETHTransferFailed()`.
+            mstore(0x00, 0xb15db189) // `DirectETHTransferNotAllowed()`.
             revert(0x1c, 0x04)
         }
     }

--- a/src/facets/CheckInFacet.sol
+++ b/src/facets/CheckInFacet.sol
@@ -9,8 +9,12 @@ contract CheckInFacet is ICheckIn {
     //                             EXTERNAL FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*//
 
-    function checkIn(uint64 _ticketId, address _ticketOwner, uint40 _tokenId) external {
-        CheckInLib.checkin(_ticketId, _ticketOwner, _tokenId);
+    function checkIn(uint64 _ticketId, uint40 _tokenId) external {
+        CheckInLib.checkin(_ticketId, _tokenId);
+    }
+
+    function checkInBatch(uint64 _ticketId, uint40[] calldata _tokenIds) external {
+        CheckInLib.checkinBatch(_ticketId, _tokenIds);
     }
 
     //*//////////////////////////////////////////////////////////////////////////

--- a/src/facets/MarketplaceFacet.sol
+++ b/src/facets/MarketplaceFacet.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.30;
 
 import {IMarketplace} from "@ticket/interfaces/IMarketplace.sol";
-import {FeeType} from "@ticket/libs/MarketplaceLib.sol";
+import {FeeType, FiatVoucher} from "@ticket/libs/MarketplaceLib.sol";
 import {MarketplaceLib} from "@ticket/libs/MarketplaceLib.sol";
 
 contract MarketplaceFacet is IMarketplace {
@@ -29,6 +29,46 @@ contract MarketplaceFacet is IMarketplace {
 
     function withdrawHostItBalance(FeeType _feeType, address _to) external {
         MarketplaceLib.withdrawHostItBalance(_feeType, _to);
+    }
+
+    //*//////////////////////////////////////////////////////////////////////////
+    //                       FIAT PAYMENT — EXTERNAL FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*//
+
+    /// @inheritdoc IMarketplace
+    function mintFiatTicket(uint64 _ticketId, address _buyer, uint256 _amount, bytes32 _paymentId)
+        external
+        returns (uint40)
+    {
+        return MarketplaceLib.mintFiatTicket(_ticketId, _buyer, _amount, _paymentId);
+    }
+
+    /// @inheritdoc IMarketplace
+    function redeemFiatVoucher(FiatVoucher calldata _v, bytes calldata _signature) external returns (uint40) {
+        return MarketplaceLib.redeemFiatVoucher(_v, _signature);
+    }
+
+    /// @inheritdoc IMarketplace
+    function batchMintFiatTickets(
+        uint64[] calldata _ticketIds,
+        address[] calldata _buyers,
+        uint256[] calldata _amounts,
+        bytes32[] calldata _paymentIds
+    ) external returns (uint40[] memory) {
+        return MarketplaceLib.batchMintFiatTickets(_ticketIds, _buyers, _amounts, _paymentIds);
+    }
+
+    /// @inheritdoc IMarketplace
+    function batchRedeemFiatVouchers(FiatVoucher[] calldata _vouchers, bytes[] calldata _signatures)
+        external
+        returns (uint40[] memory)
+    {
+        return MarketplaceLib.batchRedeemFiatVouchers(_vouchers, _signatures);
+    }
+
+    /// @inheritdoc IMarketplace
+    function setTrustedBackend(address _backend) external {
+        MarketplaceLib.setTrustedBackend(_backend);
     }
 
     //*//////////////////////////////////////////////////////////////////////////
@@ -70,6 +110,40 @@ contract MarketplaceFacet is IMarketplace {
     }
 
     //*//////////////////////////////////////////////////////////////////////////
+    //                         FIAT PAYMENT — VIEW FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*//
+
+    /// @inheritdoc IMarketplace
+    function getTrustedBackend() external view returns (address) {
+        return MarketplaceLib.getTrustedBackend();
+    }
+
+    /// @inheritdoc IMarketplace
+    function isFiatPaidToken(uint64 _ticketId, uint40 _tokenId) external view returns (bool) {
+        return MarketplaceLib.isFiatPaidToken(_ticketId, _tokenId);
+    }
+
+    /// @inheritdoc IMarketplace
+    function isFiatPaymentIdUsed(bytes32 _paymentId) external view returns (bool) {
+        return MarketplaceLib.isFiatPaymentIdUsed(_paymentId);
+    }
+
+    /// @inheritdoc IMarketplace
+    function getTicketFiatRevenue(uint64 _ticketId) external view returns (uint256) {
+        return MarketplaceLib.getTicketFiatRevenue(_ticketId);
+    }
+
+    /// @inheritdoc IMarketplace
+    function getFiatDomainSeparator() external view returns (bytes32) {
+        return MarketplaceLib.getFiatDomainSeparator();
+    }
+
+    /// @inheritdoc IMarketplace
+    function hashFiatVoucher(FiatVoucher calldata _v) external pure returns (bytes32) {
+        return MarketplaceLib.hashFiatVoucher(_v);
+    }
+
+    //*//////////////////////////////////////////////////////////////////////////
     //                               PURE FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*//
 
@@ -81,5 +155,10 @@ contract MarketplaceFacet is IMarketplace {
     // @return {s}
     function getRefundPeriod() external pure returns (uint256) {
         return MarketplaceLib.REFUND_PERIOD;
+    }
+
+    /// @inheritdoc IMarketplace
+    function getFiatVoucherTypehash() external pure returns (bytes32) {
+        return MarketplaceLib.FIAT_VOUCHER_TYPEHASH;
     }
 }

--- a/src/interfaces/ICheckIn.sol
+++ b/src/interfaces/ICheckIn.sol
@@ -8,11 +8,18 @@ interface ICheckIn {
     //                             EXTERNAL FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*//
 
-    /// @notice Checks in a ticket for a user
+    /// @notice Checks in the holder of a ticket token on their behalf
+    /// @dev The holder is derived from `ITicket.ownerOf(_tokenId)`; callable only by a ticket admin
     /// @param _ticketId The ID of the ticket to check in
-    /// @param _ticketOwner The owner of the ticket
     /// @param _tokenId The token ID of the ticket
-    function checkIn(uint64 _ticketId, address _ticketOwner, uint40 _tokenId) external;
+    function checkIn(uint64 _ticketId, uint40 _tokenId) external;
+
+    /// @notice Checks in the holders of multiple ticket tokens on their behalf in a single call
+    /// @dev Reverts on an empty array. Each tokenId's holder is derived from `ITicket.ownerOf`.
+    ///      Duplicate holders within the same call revert with `AlreadyCheckedInForDay`.
+    /// @param _ticketId The ID of the ticket to check in
+    /// @param _tokenIds The token IDs to check in
+    function checkInBatch(uint64 _ticketId, uint40[] calldata _tokenIds) external;
 
     //*//////////////////////////////////////////////////////////////////////////
     //                               VIEW FUNCTIONS

--- a/src/interfaces/IMarketplace.sol
+++ b/src/interfaces/IMarketplace.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.30;
 
-import {FeeType} from "@ticket/libs/MarketplaceLib.sol";
+import {FeeType, FiatVoucher} from "@ticket/libs/MarketplaceLib.sol";
 
 /// @title Marketplace interface
 /// @notice Interface for the Marketplace facet
@@ -13,34 +13,70 @@ interface IMarketplace {
 
     /// @notice Mints a ticket for the specified buyer
     /// @param ticketId {ticketId} The ID of the ticket to mint
-    /// @param feeType The type of fee to use for the ticket
+    /// @param feeType The type of fee to use for the ticket (must not be FIAT — use the fiat entry points)
     /// @param buyer {addr} The address of the buyer
     /// @return {ticket} The token ID of the minted ticket
     function mintTicket(uint64 ticketId, FeeType feeType, address buyer) external payable returns (uint40);
 
-    /// @notice Update the fees for the specified ticket
+    /// @notice Update the fees for the specified ticket. FIAT is not settable — fiat pricing is carried in
+    ///         the voucher / direct-call arg only.
     /// @param ticketId {ticketId} The ID of the ticket to set fees for
     /// @param feeTypes The types of fees to set
     /// @param fees {tok} The fees to set
     function updateTicketFees(uint64 ticketId, FeeType[] calldata feeTypes, uint256[] calldata fees) external;
 
-    /// @notice Claims a refund for the specified ticket
+    /// @notice Claims a refund for the specified ticket. Reverts for fiat-paid tokens (settled off-chain).
     /// @param ticketId {ticketId} The ID of the ticket to claim a refund for
     /// @param feeType The type of fee to claim a refund for
     /// @param tokenId {ticket} The token ID of the ticket to claim a refund for
     /// @param to {addr} The address to send the refund to
     function claimRefund(uint64 ticketId, FeeType feeType, uint256 tokenId, address to) external;
 
-    /// @notice Withdraws the ticket balance for the specified ticket
+    /// @notice Withdraws the ticket balance for the specified ticket. Reverts for FIAT.
     /// @param ticketId {ticketId} The ID of the ticket to withdraw the balance for
     /// @param feeType The type of fee to withdraw the balance for
     /// @param to {addr} The address to send the balance to
     function withdrawTicketBalance(uint64 ticketId, FeeType feeType, address to) external;
 
-    /// @notice Withdraws the HostIt balance for the specified fee type
+    /// @notice Withdraws the HostIt balance for the specified fee type. Reverts for FIAT.
     /// @param feeType The type of fee to withdraw the balance for
     /// @param to {addr} The address to send the balance to
     function withdrawHostItBalance(FeeType feeType, address to) external;
+
+    //*//////////////////////////////////////////////////////////////////////////
+    //                       FIAT PAYMENT — EXTERNAL FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*//
+
+    /// @notice Backend-only direct fiat mint. Caller must be the configured trusted backend.
+    /// @param ticketId {ticketId} The ID of the ticket to mint
+    /// @param buyer {addr} The address that receives the NFT
+    /// @param amount {fiat} The fiat amount charged off-chain, in smallest fiat unit
+    /// @param paymentId Backend-generated globally unique identifier; replay-protected
+    /// @return {ticket} The token ID of the minted ticket
+    function mintFiatTicket(uint64 ticketId, address buyer, uint256 amount, bytes32 paymentId) external returns (uint40);
+
+    /// @notice Redeem a backend-signed EIP-712 voucher. Anyone (typically the buyer) may submit.
+    /// @param v The signed FiatVoucher
+    /// @param signature The trusted backend's EIP-712 signature over `v`
+    /// @return {ticket} The token ID of the minted ticket
+    function redeemFiatVoucher(FiatVoucher calldata v, bytes calldata signature) external returns (uint40);
+
+    /// @notice Backend-only batch direct fiat mint. Atomic — any per-item revert rolls back the whole tx.
+    function batchMintFiatTickets(
+        uint64[] calldata ticketIds,
+        address[] calldata buyers,
+        uint256[] calldata amounts,
+        bytes32[] calldata paymentIds
+    ) external returns (uint40[] memory);
+
+    /// @notice Batch voucher redemption. Each voucher verified independently. Atomic.
+    function batchRedeemFiatVouchers(FiatVoucher[] calldata vouchers, bytes[] calldata signatures)
+        external
+        returns (uint40[] memory);
+
+    /// @notice Owner-only setter for the trusted backend address. `address(0)` disables both fiat paths.
+    /// @param backend {addr} The new trusted backend address
+    function setTrustedBackend(address backend) external;
 
     //*//////////////////////////////////////////////////////////////////////////
     //                               VIEW FUNCTIONS
@@ -86,6 +122,30 @@ interface IMarketplace {
     function getHostItBalance(FeeType feeType) external view returns (uint256);
 
     //*//////////////////////////////////////////////////////////////////////////
+    //                         FIAT PAYMENT — VIEW FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*//
+
+    /// @notice Currently-configured trusted backend address.
+    /// @return {addr}
+    function getTrustedBackend() external view returns (address);
+
+    /// @notice Whether a given (ticketId, tokenId) was minted via the fiat path.
+    function isFiatPaidToken(uint64 ticketId, uint40 tokenId) external view returns (bool);
+
+    /// @notice Whether a given paymentId has been redeemed already.
+    function isFiatPaymentIdUsed(bytes32 paymentId) external view returns (bool);
+
+    /// @notice Lifetime fiat revenue recorded on-chain for a given ticket.
+    /// @return {fiat}
+    function getTicketFiatRevenue(uint64 ticketId) external view returns (uint256);
+
+    /// @notice EIP-712 domain separator the trusted backend must sign against.
+    function getFiatDomainSeparator() external view returns (bytes32);
+
+    /// @notice EIP-712 struct hash of a voucher (helper for integrators).
+    function hashFiatVoucher(FiatVoucher calldata v) external pure returns (bytes32);
+
+    //*//////////////////////////////////////////////////////////////////////////
     //                               PURE FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*//
 
@@ -97,4 +157,7 @@ interface IMarketplace {
     /// @notice Gets the refund period
     /// @return {s} The refund period
     function getRefundPeriod() external pure returns (uint256);
+
+    /// @notice EIP-712 typehash for FiatVoucher.
+    function getFiatVoucherTypehash() external pure returns (bytes32);
 }

--- a/src/interfaces/ITicket.sol
+++ b/src/interfaces/ITicket.sol
@@ -17,6 +17,16 @@ interface ITicket is IERC721Metadata, IERC721Enumerable {
     /// @param newSymbol The new symbol of the NFT collection
     event SymbolUpdated(string indexed newSymbol);
 
+    /// @notice Emitted when a ticket is used
+    /// @param tokenId The ID of the token that was used
+    event TicketUsed(uint256 indexed tokenId);
+
+    /// @dev The name of the NFT collection cannot be empty
+    error NameCannotBeEmpty();
+
+    /// @dev The ticket has already been used
+    error TicketAlreadyUsed();
+
     /// @notice Initializes the contract
     /// @param owner The owner of the contract
     /// @param name The name of the NFT collection
@@ -36,21 +46,26 @@ interface ITicket is IERC721Metadata, IERC721Enumerable {
     /// forge-lint: disable-next-line(mixed-case-function)
     function updateURI(string calldata _uri) external;
 
+    /// @notice Uses a ticket, marking it as used and preventing future use
+    /// @param _tokenId The ID of the token to use
+    function useTicket(uint256 _tokenId) external;
+
+    /// @notice Refunds a ticket
+    /// @param _to The address to send refunded ticket
+    /// @param _tokenId The ID of the ticket to refund
+    function refundTicket(address _to, uint256 _tokenId) external;
+
     /// @notice Mints a new token to a given address
     /// @param _to The address to receive the newly minted token
     /// @return tokenId_ The ID of the newly minted token
     function mint(address _to) external returns (uint256 tokenId_);
 
-    /// @notice Pauses token transfers
-    function pause() external;
-
-    /// @notice Unpauses token transfers
-    function unpause() external;
-
     /// @notice Returns the base URI of the NFT collection
     /// forge-lint: disable-next-line(mixed-case-function)
     function baseURI() external view returns (string memory);
 
-    /// @notice Checks if token transfers are paused
-    function paused() external view returns (bool);
+    /// @notice Checks if a ticket has been used
+    /// @param _tokenId The ID of the token to check
+    /// @return True if the ticket has been used, false otherwise
+    function isUsed(uint256 _tokenId) external view returns (bool);
 }

--- a/src/libs/CheckInLib.sol
+++ b/src/libs/CheckInLib.sol
@@ -96,9 +96,13 @@ library CheckInLib {
         }
     }
 
-    function _recordCheckIn(CheckInStorage storage _cs, uint64 _ticketId, uint8 _day, address _ticketOwner, uint40 _tokenId)
-        private
-    {
+    function _recordCheckIn(
+        CheckInStorage storage _cs,
+        uint64 _ticketId,
+        uint8 _day,
+        address _ticketOwner,
+        uint40 _tokenId
+    ) private {
         _cs.checkedIn[_ticketId].add(_ticketOwner);
         if (!_cs.checkedInByDay[_ticketId][_day].add(_ticketOwner)) revert AlreadyCheckedInForDay(_day);
         emit CheckedIn(_ticketId, _ticketOwner, _day, _tokenId);

--- a/src/libs/CheckInLib.sol
+++ b/src/libs/CheckInLib.sol
@@ -4,12 +4,13 @@ pragma solidity 0.8.30;
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {ITicket} from "@ticket/interfaces/ITicket.sol";
 import {ExtraTicketData, FactoryLib} from "@ticket/libs/FactoryLib.sol";
+import {SafeCastLib} from "solady/utils/SafeCastLib.sol";
 
 //*//////////////////////////////////////////////////////////////////////////
 //                                   EVENTS
 //////////////////////////////////////////////////////////////////////////*//
 
-event CheckedIn(uint64 indexed ticketId, address indexed ticketOwner, uint40 tokenId);
+event CheckedIn(uint64 indexed ticketId, address indexed ticketOwner, uint8 indexed day, uint40 tokenId);
 
 //*//////////////////////////////////////////////////////////////////////////
 //                                   ERRORS
@@ -17,9 +18,9 @@ event CheckedIn(uint64 indexed ticketId, address indexed ticketOwner, uint40 tok
 
 error TicketUsePeriodNotStarted();
 error TicketUsePeriodHasEnded();
-error NotTicketOwner(uint40);
 error AlreadyCheckedInForDay(uint8);
-error TicketPauseFailed();
+error TicketCallFailed();
+error EmptyBatch();
 
 //*//////////////////////////////////////////////////////////////////////////
 //                              CHECKIN STORAGE
@@ -54,55 +55,86 @@ library CheckInLib {
     //////////////////////////////////////////////////////////////////////////*//
 
     /// @param _ticketId {ticketId}
-    /// @param _ticketOwner {addr}
     /// @param _tokenId {ticket}
-    function checkin(uint64 _ticketId, address _ticketOwner, uint40 _tokenId) internal onlyTicketAdmin(_ticketId) {
-        FactoryLib.checkTicketExists(_ticketId);
-
-        uint40 time = uint40(block.timestamp); // {s}
+    function checkin(uint64 _ticketId, uint40 _tokenId) internal onlyTicketAdmin(_ticketId) {
         ExtraTicketData memory ticketData = FactoryLib.getExtraTicketData(_ticketId);
+        uint48 time = SafeCastLib.toUint48(block.timestamp); // {s}
 
         if (time < ticketData.startTime) revert TicketUsePeriodNotStarted();
         if (time > ticketData.endTime) revert TicketUsePeriodHasEnded();
 
         ITicket ticket = ITicket(ticketData.ticketAddress);
-        if (ticket.ownerOf(_tokenId) != _ticketOwner) revert NotTicketOwner(_tokenId);
-
-        if (!ticket.paused()) {
-            try ticket.pause() {}
-            catch {
-                revert TicketPauseFailed();
-            }
-        }
-
-        CheckInStorage storage cs = checkInStorage();
-
-        cs.checkedIn[_ticketId].add(_ticketOwner);
+        ticket.useTicket(_tokenId);
 
         // {day} = ({s} - {s}) / {s}
         uint8 day = uint8((time - ticketData.startTime) / 1 days);
-        if (!cs.checkedInByDay[_ticketId][day].add(_ticketOwner)) revert AlreadyCheckedInForDay(day);
+        _recordCheckIn(checkInStorage(), _ticketId, day, ticket.ownerOf(_tokenId), _tokenId);
+    }
 
-        emit CheckedIn(_ticketId, _ticketOwner, _tokenId);
+    /// @param _ticketId {ticketId}
+    /// @param _tokenIds {ticket}[] tokens whose holders should be marked checked-in
+    function checkinBatch(uint64 _ticketId, uint40[] calldata _tokenIds) internal onlyTicketAdmin(_ticketId) {
+        uint256 len = _tokenIds.length;
+        if (len == 0) revert EmptyBatch();
+
+        ExtraTicketData memory ticketData = FactoryLib.getExtraTicketData(_ticketId);
+        uint48 time = SafeCastLib.toUint48(block.timestamp); // {s}
+
+        if (time < ticketData.startTime) revert TicketUsePeriodNotStarted();
+        if (time > ticketData.endTime) revert TicketUsePeriodHasEnded();
+
+        ITicket ticket = ITicket(ticketData.ticketAddress);
+
+        // {day} = ({s} - {s}) / {s}
+        uint8 day = uint8((time - ticketData.startTime) / 1 days);
+        CheckInStorage storage cs = checkInStorage();
+
+        for (uint256 i; i < len; ++i) {
+            uint40 tokenId = _tokenIds[i];
+            ticket.useTicket(tokenId);
+            _recordCheckIn(cs, _ticketId, day, ticket.ownerOf(tokenId), tokenId);
+        }
+    }
+
+    function _recordCheckIn(CheckInStorage storage _cs, uint64 _ticketId, uint8 _day, address _ticketOwner, uint40 _tokenId)
+        private
+    {
+        _cs.checkedIn[_ticketId].add(_ticketOwner);
+        if (!_cs.checkedInByDay[_ticketId][_day].add(_ticketOwner)) revert AlreadyCheckedInForDay(_day);
+        emit CheckedIn(_ticketId, _ticketOwner, _day, _tokenId);
     }
 
     //*//////////////////////////////////////////////////////////////////////////
     //                               VIEW FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*//
+
+    /// @notice Checks if the specified address has checked in for the specified ticket
+    /// @param _ticketId The ID of the ticket
+    /// @param _ticketOwner The address of the ticket owner to check
+    /// @return True if the address has checked in, false otherwise
     function isCheckedIn(uint64 _ticketId, address _ticketOwner) internal view returns (bool) {
         return checkInStorage().checkedIn[_ticketId].contains(_ticketOwner);
     }
 
-    /// @param _day {day}
+    /// @notice Checks if the specified address has checked in for the specified ticket and day
+    /// @param _ticketId The ID of the ticket
+    /// @param _day The day for which to check
+    /// @param _ticketOwner The address of the ticket owner to check
+    /// @return True if the address has checked in, false otherwise
     function isCheckedInForDay(uint64 _ticketId, uint8 _day, address _ticketOwner) internal view returns (bool) {
         return checkInStorage().checkedInByDay[_ticketId][_day].contains(_ticketOwner);
     }
 
+    /// @notice Gets the list of addresses that have checked in for the specified ticket
+    /// @param _ticketId The ID of the ticket
     function getCheckedIn(uint64 _ticketId) internal view returns (address[] memory) {
         return checkInStorage().checkedIn[_ticketId].values();
     }
 
     /// @param _day {day}
+    /// @notice Gets the list of addresses that have checked in for the specified ticket and day
+    /// @param _ticketId The ID of the ticket
+    /// @param _day The day for which to get checked-in addresses
     function getCheckedInForDay(uint64 _ticketId, uint8 _day) internal view returns (address[] memory) {
         return checkInStorage().checkedInByDay[_ticketId][_day].values();
     }

--- a/src/libs/FactoryLib.sol
+++ b/src/libs/FactoryLib.sol
@@ -7,6 +7,7 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 import {ITicket} from "@ticket/interfaces/ITicket.sol";
 import {FeeType, MarketplaceLib, MarketplaceStorage} from "@ticket/libs/MarketplaceLib.sol";
 import {LibClone} from "solady/utils/LibClone.sol";
+import {SafeCastLib} from "solady/utils/SafeCastLib.sol";
 
 event TicketCreated(uint64 indexed ticketId, address indexed ticketAdmin, ExtraTicketData ticketData);
 
@@ -135,7 +136,7 @@ library FactoryLib {
             if (bytes(_ticketData.uri).length == 0) revert EmptyURI();
 
             // {s} < {s}
-            if (_ticketData.startTime < block.timestamp) {
+            if (_ticketData.startTime < SafeCastLib.toUint48(block.timestamp)) {
                 revert StartTimeShouldBeAhead();
             }
             // {s} < {s} + {s}
@@ -174,7 +175,7 @@ library FactoryLib {
 
         if (_ticketData.startTime != 0) {
             // {s} < {s}
-            if (_ticketData.startTime < uint40(block.timestamp)) {
+            if (_ticketData.startTime < SafeCastLib.toUint48(block.timestamp)) {
                 revert StartTimeShouldBeAhead();
             }
             extraTicketData.startTime = _ticketData.startTime; // {s}
@@ -182,7 +183,7 @@ library FactoryLib {
 
         if (_ticketData.endTime != 0) {
             // {s} < {s} + {s}
-            if (_ticketData.endTime < _ticketData.startTime + 1 days) {
+            if (_ticketData.endTime < extraTicketData.startTime + 1 days) {
                 revert EndTimeShouldBeAtLeastADayAfterStartTime();
             }
             extraTicketData.endTime = _ticketData.endTime; // {s}
@@ -190,7 +191,7 @@ library FactoryLib {
 
         if (_ticketData.purchaseStartTime != 0) {
             // {s} > {s} - {s}
-            if (_ticketData.purchaseStartTime > _ticketData.startTime - 1 days) {
+            if (_ticketData.purchaseStartTime > extraTicketData.startTime - 1 days) {
                 revert PurchaseStartTimeShouldBeAtLeastOneDayBeforeStartTime();
             }
             extraTicketData.purchaseStartTime = _ticketData.purchaseStartTime; // {s}
@@ -399,7 +400,7 @@ library FactoryLib {
     }
 
     function generateTicketHash(uint64 _ticketId) internal pure returns (bytes32 ticketHash_) {
-        assembly {
+        assembly ("memory-safe") {
             let ptr := mload(0x40)
             mstore(ptr, HOST_IT_TICKET)
             mstore(add(ptr, 0x20), _ticketId)
@@ -408,7 +409,7 @@ library FactoryLib {
     }
 
     function generateMainTicketAdminRole(uint64 _ticketId) internal pure returns (bytes32 mainTicketAdminRole_) {
-        assembly {
+        assembly ("memory-safe") {
             let ptr := mload(0x40)
             mstore(ptr, HOST_IT_MAIN_TICKET_ADMIN)
             mstore(add(ptr, 0x20), _ticketId)
@@ -417,7 +418,7 @@ library FactoryLib {
     }
 
     function generateTicketAdminRole(uint64 _ticketId) internal pure returns (bytes32 ticketAdminRole_) {
-        assembly {
+        assembly ("memory-safe") {
             let ptr := mload(0x40)
             mstore(ptr, HOST_IT_TICKET_ADMIN)
             mstore(add(ptr, 0x20), _ticketId)

--- a/src/libs/MarketplaceLib.sol
+++ b/src/libs/MarketplaceLib.sol
@@ -15,8 +15,6 @@ event TicketFeeSet(uint64 indexed ticketId, FeeType[] feeType, uint256[] fee); /
 
 event TicketRefunded(uint64 indexed ticketId, FeeType indexed feeType, uint256 fee, address indexed to); // fee:{tok}
 
-event HostItFeeBpsSet(uint16 indexed hostItFeeBps); // hostItFeeBps:BPS{1}
-
 event TicketFeeAddressSet(FeeType[] feeType, address[] token); // token:{addr}
 
 event TicketMinted(uint64 indexed ticketId, FeeType indexed feeType, uint256 fee, uint40 tokenId); // fee:{tok}, tokenId:{ticket}
@@ -34,7 +32,6 @@ error InvalidFeeConfig();
 error ZeroFee(FeeType);
 error TicketIsFree();
 error FeeNotEnabled(uint64, FeeType);
-error TicketNotApproved(uint256);
 error InsufficientBalance(address, FeeType, uint256);
 error InsufficientAllowance(address, FeeType, uint256);
 error RefundNotEnabled();
@@ -47,7 +44,6 @@ error InsufficientPayment(FeeType, uint256);
 error PaymentFailed(FeeType, uint256);
 error TicketAccountingMismatch();
 error CreateERC6551AccountFailed();
-error InvalidHostItFeeBps();
 
 // keccak256(abi.encode(uint256(keccak256("host.it.ticket.marketplace.storage")) - 1)) & ~bytes32(uint256(0xff))
 bytes32 constant MARKETPLACE_STORAGE_LOCATION = 0x3f09c55b469305b27ecae2a46b3f364669f622316549d801837d9eeba9778d00;
@@ -56,8 +52,8 @@ bytes32 constant MARKETPLACE_STORAGE_LOCATION = 0x3f09c55b469305b27ecae2a46b3f36
 /// @notice Enum for fee types
 enum FeeType {
     NONE,
-    ETH,
-    WETH,
+    NATIVE,
+    WNATIVE,
     USDT,
     USDC,
     USDT0,
@@ -83,7 +79,6 @@ library MarketplaceLib {
     //////////////////////////////////////////////////////////////////////////*//
 
     uint256 internal constant REFUND_PERIOD = 3 days; // {s}
-
     uint256 private constant HOSTIT_FEE_BPS = 300; // BPS{1} 3% fee in basis points
     uint256 private constant FEE_BASIS_POINTS = 10_000; // BPS{1} 10,000 basis points
 
@@ -107,52 +102,52 @@ library MarketplaceLib {
 
         {
             uint48 time = SafeCastLib.toUint48(block.timestamp); // {s}
-            // {s} < {s}
-            if (time < ticketData.purchaseStartTime) {
-                revert PurchaseTimeNotReached();
-            }
-            if (time > ticketData.endTime) revert PurchaseTimeNotReached(); // {s} > {s}
             if (ticketData.soldTickets == ticketData.maxTickets) {
                 // {ticket} == {ticket}
                 revert TicketSoldOut();
             }
+            // {s} < {s}
+            if (time < ticketData.purchaseStartTime) revert PurchaseTimeNotReached();
+            if (time > ticketData.endTime) revert PurchaseTimeNotReached(); // {s} > {s}
         }
 
         ITicket ticket = ITicket(ticketData.ticketAddress);
-        // {ticket} > {ticket}
-        if (ticket.balanceOf(_buyer) > ticketData.maxTicketsPerUser) {
+        // {ticket} >= {ticket}
+        if (ticket.balanceOf(_buyer) >= ticketData.maxTicketsPerUser) {
             revert MaxTicketsHeld();
         }
 
+        address msgSender = ContextLib.msgSender();
         MarketplaceStorage storage ms = marketplaceStorage();
         // {tok}, {tok}, {tok}
         (uint256 fee, uint256 hostItFee, uint256 totalFee) = getFees(ms, _ticketId, _feeType);
         if (!ticketData.isFree) {
-            if (!_feeEnabled(ms, _ticketId, _feeType)) revert FeeNotEnabled(_ticketId, _feeType);
+            if (!feeEnabled(ms, _ticketId, _feeType)) revert FeeNotEnabled(_ticketId, _feeType);
 
+            ms.hostItBalance[_feeType] += hostItFee; // {tok} += {tok}
             if (ticketData.isRefundable) {
-                if (_feeType == FeeType.ETH) {
+                if (_feeType == FeeType.NATIVE) {
                     // {tok} < {tok}
                     if (msg.value < totalFee) {
                         revert InsufficientPayment(_feeType, totalFee);
                     }
-                    // Refund excess ETH if user overpays
+                    // Refund excess NATIVE if user overpays
                     if (msg.value > totalFee) {
-                        SafeTransferLib.forceSafeTransferETH(ContextLib.msgSender(), msg.value - totalFee);
+                        SafeTransferLib.forceSafeTransferETH(msgSender, msg.value - totalFee);
                     }
                 } else {
                     _payWithToken(ms, _feeType, totalFee, address(this));
                 }
                 ms.ticketBalance[_ticketId][_feeType] += fee; // {tok} += {tok}
             } else {
-                if (_feeType == FeeType.ETH) {
+                if (_feeType == FeeType.NATIVE) {
                     // {tok} < {tok}
                     if (msg.value < totalFee) {
                         revert InsufficientPayment(_feeType, totalFee);
                     }
-                    // Refund excess ETH if user overpays
+                    // Refund excess NATIVE if user overpays
                     if (msg.value > totalFee) {
-                        SafeTransferLib.forceSafeTransferETH(ContextLib.msgSender(), msg.value - totalFee);
+                        SafeTransferLib.forceSafeTransferETH(msgSender, msg.value - totalFee);
                     }
                     SafeTransferLib.forceSafeTransferETH(ticketData.ticketAdmin, fee);
                 } else {
@@ -160,7 +155,6 @@ library MarketplaceLib {
                     _payWithToken(ms, _feeType, hostItFee, address(this));
                 }
             }
-            ms.hostItBalance[_feeType] += hostItFee; // {tok} += {tok}
         }
 
         tokenId_ = SafeCastLib.toUint40(ticket.mint(_buyer)); // {ticket}
@@ -202,6 +196,12 @@ library MarketplaceLib {
 
     /// @param _ticketId {ticketId}
     /// @param _tokenId {ticket}
+    function claimRefund(uint64 _ticketId, FeeType _feeType, uint256 _tokenId) internal {
+        claimRefund(_ticketId, _feeType, _tokenId, msg.sender);
+    }
+
+    /// @param _ticketId {ticketId}
+    /// @param _tokenId {ticket}
     /// @param _to {addr}
     function claimRefund(uint64 _ticketId, FeeType _feeType, uint256 _tokenId, address _to) internal {
         FactoryLib.checkTicketExists(_ticketId);
@@ -226,7 +226,7 @@ library MarketplaceLib {
 
         ticket.refundTicket(ticketData.ticketAdmin, _tokenId);
 
-        if (_feeType == FeeType.ETH) {
+        if (_feeType == FeeType.NATIVE) {
             SafeTransferLib.safeTransferETH(_to, ticketFee);
         } else {
             SafeTransferLib.safeTransfer(getFeeTokenAddress(_feeType), _to, ticketFee);
@@ -248,7 +248,7 @@ library MarketplaceLib {
 
         if (ticketData.isRefundable) {
             // {s} < {s} + {s}
-            if (block.timestamp < ticketData.endTime + REFUND_PERIOD) {
+            if (SafeCastLib.toUint48(block.timestamp) < ticketData.endTime + REFUND_PERIOD) {
                 revert WithdrawPeriodNotReached();
             }
         }
@@ -257,8 +257,8 @@ library MarketplaceLib {
         if (balance == 0) revert InsufficientWithdrawBalance();
         delete marketplaceStorage().ticketBalance[_ticketId][_feeType];
 
-        if (_feeType == FeeType.ETH) {
-            SafeTransferLib.safeTransferETH(_to, balance);
+        if (_feeType == FeeType.NATIVE) {
+            SafeTransferLib.forceSafeTransferETH(_to, balance);
         } else {
             SafeTransferLib.safeTransfer(getFeeTokenAddress(_feeType), _to, balance);
         }
@@ -274,7 +274,7 @@ library MarketplaceLib {
         if (balance == 0) revert InsufficientWithdrawBalance();
         delete marketplaceStorage().hostItBalance[_feeType];
 
-        if (_feeType == FeeType.ETH) {
+        if (_feeType == FeeType.NATIVE) {
             SafeTransferLib.forceSafeTransferETH(_to, balance);
         } else {
             SafeTransferLib.safeTransfer(getFeeTokenAddress(_feeType), _to, balance);
@@ -289,15 +289,15 @@ library MarketplaceLib {
 
         address tokenAddress = getFeeTokenAddress(_ms, _feeType); // {addr}
         IERC20 token = IERC20(tokenAddress);
-        // {tok} < {tok}
-        if (token.balanceOf(caller) < _totalFee) {
-            revert InsufficientBalance(tokenAddress, _feeType, _totalFee);
-        }
-        // {tok} < {tok}
-        if (token.allowance(caller, address(this)) < _totalFee) {
-            revert InsufficientAllowance(tokenAddress, _feeType, _totalFee);
-        }
         if (!SafeTransferLib.trySafeTransferFrom(tokenAddress, caller, _to, _totalFee)) {
+            // {tok} < {tok}
+            if (token.balanceOf(caller) < _totalFee) {
+                revert InsufficientBalance(tokenAddress, _feeType, _totalFee);
+            }
+            // {tok} < {tok}
+            if (token.allowance(caller, address(this)) < _totalFee) {
+                revert InsufficientAllowance(tokenAddress, _feeType, _totalFee);
+            }
             revert PaymentFailed(_feeType, _totalFee);
         }
     }
@@ -336,10 +336,10 @@ library MarketplaceLib {
     //////////////////////////////////////////////////////////////////////////*//
 
     function feeEnabled(uint64 _ticketId, FeeType _feeType) internal view returns (bool) {
-        return _feeEnabled(marketplaceStorage(), _ticketId, _feeType);
+        return feeEnabled(marketplaceStorage(), _ticketId, _feeType);
     }
 
-    function _feeEnabled(MarketplaceStorage storage _ms, uint64 _ticketId, FeeType _feeType)
+    function feeEnabled(MarketplaceStorage storage _ms, uint64 _ticketId, FeeType _feeType)
         internal
         view
         returns (bool)

--- a/src/libs/MarketplaceLib.sol
+++ b/src/libs/MarketplaceLib.sol
@@ -242,8 +242,6 @@ library MarketplaceLib {
         onlyMainTicketAdmin(_ticketId)
     {
         FactoryLib.checkTicketExists(_ticketId);
-        _checkIfContract(_to);
-
         ExtraTicketData memory ticketData = FactoryLib.getExtraTicketData(_ticketId);
 
         if (ticketData.isRefundable) {
@@ -268,8 +266,6 @@ library MarketplaceLib {
 
     /// @param _to {addr}
     function withdrawHostItBalance(FeeType _feeType, address _to) internal onlyOwner {
-        _checkIfContract(_to);
-
         uint256 balance = getHostItBalance(_feeType); // {tok}
         if (balance == 0) revert InsufficientWithdrawBalance();
         delete marketplaceStorage().hostItBalance[_feeType];
@@ -420,10 +416,6 @@ library MarketplaceLib {
     /// @return {tok}
     function getHostItBalance(MarketplaceStorage storage _ms, FeeType _feeType) internal view returns (uint256) {
         return _ms.hostItBalance[_feeType];
-    }
-
-    function _checkIfContract(address _address) private view {
-        if (_address.code.length > 0) revert ContractNotAllowed();
     }
 
     /// @param _fee {tok}

--- a/src/libs/MarketplaceLib.sol
+++ b/src/libs/MarketplaceLib.sol
@@ -8,6 +8,7 @@ import {ACCOUNT_V3_IMPLEMENTATION, ERC6551_REGISTRY} from "@ticket-script/helper
 import {ITicket} from "@ticket/interfaces/ITicket.sol";
 import {ExtraTicketData, FactoryLib} from "@ticket/libs/FactoryLib.sol";
 import {IERC6551Registry} from "erc6551/src/interfaces/IERC6551Registry.sol";
+import {ECDSA} from "solady/utils/ECDSA.sol";
 import {SafeCastLib} from "solady/utils/SafeCastLib.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 
@@ -23,7 +24,12 @@ event TicketBalanceWithdrawn(uint64 indexed ticketId, FeeType indexed feeType, u
 
 event HostItBalanceWithdrawn(FeeType indexed feeType, uint256 fee, address indexed to); // fee:{tok}
 
-error ContractNotAllowed();
+event FiatTicketMinted(
+    uint64 indexed ticketId, address indexed buyer, uint40 tokenId, uint256 amount, bytes32 indexed paymentId
+); // amount:{fiat}, tokenId:{ticket}
+
+event TrustedBackendUpdated(address indexed previous, address indexed current);
+
 error PurchaseTimeNotReached();
 error TicketSoldOut();
 error MaxTicketsHeld();
@@ -44,12 +50,23 @@ error InsufficientPayment(FeeType, uint256);
 error PaymentFailed(FeeType, uint256);
 error TicketAccountingMismatch();
 error CreateERC6551AccountFailed();
+error UnauthorizedBackend();
+error InvalidVoucherSignature();
+error VoucherExpired();
+error PaymentIdAlreadyUsed(bytes32);
+error InvalidPaymentId();
+error ZeroFiatAmount();
+error FiatTicketNotRefundable();
+error FiatBalanceNotWithdrawable();
+error FiatFeeTypeNotMintable();
+error FiatFeeNotSettable();
+error BatchLengthMismatch();
 
 // keccak256(abi.encode(uint256(keccak256("host.it.ticket.marketplace.storage")) - 1)) & ~bytes32(uint256(0xff))
 bytes32 constant MARKETPLACE_STORAGE_LOCATION = 0x3f09c55b469305b27ecae2a46b3f364669f622316549d801837d9eeba9778d00;
 
 /// @title FeeType
-/// @notice Enum for fee types
+/// @notice Enum for fee types.
 enum FeeType {
     NONE,
     NATIVE,
@@ -60,17 +77,35 @@ enum FeeType {
     EURC,
     GHO,
     LINK,
-    LSK
+    LSK,
+    FIAT
+}
+
+/// @title FiatVoucher
+/// @notice Backend-signed authorization for an off-chain fiat purchase, redeemable on-chain.
+/// @dev Bound to chain + verifying contract via the EIP-712 domain.
+struct FiatVoucher {
+    uint64 ticketId;
+    address buyer;
+    uint256 amount; // {fiat} smallest fiat unit charged (e.g. cents)
+    bytes32 paymentId; // backend-generated, globally unique
+    uint48 expiresAt; // {s}
 }
 
 /// @title MarketplaceStorage
-/// @notice Storage structure for managing marketplace data
+/// @notice Storage structure for managing marketplace data. Fields below the divider were appended for the
+///         off-chain fiat payment feature; further fields must continue to be appended (ERC-7201 invariant).
 /// @custom:storage-location erc7201:host.it.ticket.marketplace.storage
 struct MarketplaceStorage {
     mapping(uint64 => mapping(FeeType => uint256)) ticketFee; // {ticketId} => FeeType => {tok}
     mapping(uint64 => mapping(FeeType => uint256)) ticketBalance; // {ticketId} => FeeType => {tok}
     mapping(FeeType => address) feeTokenAddress; // FeeType => {addr}
     mapping(FeeType => uint256) hostItBalance; // FeeType => {tok}
+    // --- FIAT storage ---
+    address trustedBackend; // owner-managed signer + direct caller
+    mapping(bytes32 => bool) usedFiatPaymentIds; // replay guard
+    mapping(uint64 => mapping(uint40 => bool)) isFiatPaidToken; // (ticketId, tokenId) => fiat-paid flag
+    mapping(uint64 => uint256) ticketFiatRevenue; // {ticketId} => {fiat} lifetime fiat revenue
 }
 
 library MarketplaceLib {
@@ -81,6 +116,13 @@ library MarketplaceLib {
     uint256 internal constant REFUND_PERIOD = 3 days; // {s}
     uint256 private constant HOSTIT_FEE_BPS = 300; // BPS{1} 3% fee in basis points
     uint256 private constant FEE_BASIS_POINTS = 10_000; // BPS{1} 10,000 basis points
+
+    bytes32 internal constant FIAT_VOUCHER_TYPEHASH =
+        keccak256("FiatVoucher(uint64 ticketId,address buyer,uint256 amount,bytes32 paymentId,uint48 expiresAt)");
+    bytes32 private constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 private constant EIP712_NAME_HASH = keccak256(bytes("HostItTickets"));
+    bytes32 private constant EIP712_VERSION_HASH = keccak256(bytes("1"));
 
     function marketplaceStorage() internal pure returns (MarketplaceStorage storage ms_) {
         assembly {
@@ -96,26 +138,9 @@ library MarketplaceLib {
     /// @param _buyer {addr}
     /// @return tokenId_ {ticket}
     function mintTicket(uint64 _ticketId, FeeType _feeType, address _buyer) internal returns (uint40 tokenId_) {
-        FactoryLib.checkTicketExists(_ticketId);
+        if (_feeType == FeeType.FIAT) revert FiatFeeTypeNotMintable();
 
-        ExtraTicketData memory ticketData = FactoryLib.getExtraTicketData(_ticketId);
-
-        {
-            uint48 time = SafeCastLib.toUint48(block.timestamp); // {s}
-            if (ticketData.soldTickets == ticketData.maxTickets) {
-                // {ticket} == {ticket}
-                revert TicketSoldOut();
-            }
-            // {s} < {s}
-            if (time < ticketData.purchaseStartTime) revert PurchaseTimeNotReached();
-            if (time > ticketData.endTime) revert PurchaseTimeNotReached(); // {s} > {s}
-        }
-
-        ITicket ticket = ITicket(ticketData.ticketAddress);
-        // {ticket} >= {ticket}
-        if (ticket.balanceOf(_buyer) >= ticketData.maxTicketsPerUser) {
-            revert MaxTicketsHeld();
-        }
+        ExtraTicketData memory ticketData = _preMintChecks(_ticketId, _buyer);
 
         address msgSender = ContextLib.msgSender();
         MarketplaceStorage storage ms = marketplaceStorage();
@@ -157,14 +182,7 @@ library MarketplaceLib {
             }
         }
 
-        tokenId_ = SafeCastLib.toUint40(ticket.mint(_buyer)); // {ticket}
-        ++FactoryLib.factoryStorage().ticketIdToData[_ticketId].soldTickets; // {ticket}
-        // {ticket} != {ticket}
-        if (tokenId_ != FactoryLib.factoryStorage().ticketIdToData[_ticketId].soldTickets) {
-            revert TicketAccountingMismatch();
-        }
-
-        emit TicketMinted(_ticketId, _feeType, totalFee, tokenId_);
+        tokenId_ = _finalizeMint(ticketData, _buyer, _feeType, totalFee);
     }
 
     /// @param _ticketId {ticketId}
@@ -186,6 +204,7 @@ library MarketplaceLib {
 
         MarketplaceStorage storage ms = marketplaceStorage();
         for (uint256 i; i < feeTypesLength; ++i) {
+            if (_feeTypes[i] == FeeType.FIAT) revert FiatFeeNotSettable();
             if (_fees[i] == 0) revert ZeroFee(_feeTypes[i]);
 
             ms.ticketFee[_ticketId][_feeTypes[i]] = _fees[i]; // {tok}
@@ -197,7 +216,7 @@ library MarketplaceLib {
     /// @param _ticketId {ticketId}
     /// @param _tokenId {ticket}
     function claimRefund(uint64 _ticketId, FeeType _feeType, uint256 _tokenId) internal {
-        claimRefund(_ticketId, _feeType, _tokenId, msg.sender);
+        claimRefund(_ticketId, _feeType, _tokenId, ContextLib.msgSender());
     }
 
     /// @param _ticketId {ticketId}
@@ -207,6 +226,11 @@ library MarketplaceLib {
         FactoryLib.checkTicketExists(_ticketId);
 
         ExtraTicketData memory ticketData = FactoryLib.getExtraTicketData(_ticketId);
+
+        MarketplaceStorage storage ms = marketplaceStorage();
+        if (ms.isFiatPaidToken[_ticketId][SafeCastLib.toUint40(_tokenId)]) {
+            revert FiatTicketNotRefundable();
+        }
 
         if (!ticketData.isRefundable) revert RefundNotEnabled();
 
@@ -222,7 +246,7 @@ library MarketplaceLib {
         if (caller != ticket.ownerOf(_tokenId)) revert TicketNotOwned(_tokenId); // {addr} != {addr}
 
         uint256 ticketFee = getTicketFee(_ticketId, _feeType); // {tok}
-        marketplaceStorage().ticketBalance[_ticketId][_feeType] -= ticketFee; // {tok} -= {tok}
+        ms.ticketBalance[_ticketId][_feeType] -= ticketFee; // {tok} -= {tok}
 
         ticket.refundTicket(ticketData.ticketAdmin, _tokenId);
 
@@ -241,6 +265,8 @@ library MarketplaceLib {
         internal
         onlyMainTicketAdmin(_ticketId)
     {
+        if (_feeType == FeeType.FIAT) revert FiatBalanceNotWithdrawable();
+
         FactoryLib.checkTicketExists(_ticketId);
         ExtraTicketData memory ticketData = FactoryLib.getExtraTicketData(_ticketId);
 
@@ -266,6 +292,8 @@ library MarketplaceLib {
 
     /// @param _to {addr}
     function withdrawHostItBalance(FeeType _feeType, address _to) internal onlyOwner {
+        if (_feeType == FeeType.FIAT) revert FiatBalanceNotWithdrawable();
+
         uint256 balance = getHostItBalance(_feeType); // {tok}
         if (balance == 0) revert InsufficientWithdrawBalance();
         delete marketplaceStorage().hostItBalance[_feeType];
@@ -309,6 +337,70 @@ library MarketplaceLib {
         } catch {
             revert CreateERC6551AccountFailed();
         }
+    }
+
+    //*//////////////////////////////////////////////////////////////////////////
+    //                        FIAT PAYMENT — INTERNAL FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*//
+
+    /// @notice Direct backend-call path. Only the configured `trustedBackend` may call.
+    /// @param _ticketId {ticketId}
+    /// @param _buyer {addr}
+    /// @param _amount {fiat} smallest unit charged off-chain
+    /// @param _paymentId backend-generated globally unique payment identifier
+    /// @return tokenId_ {ticket}
+    function mintFiatTicket(uint64 _ticketId, address _buyer, uint256 _amount, bytes32 _paymentId)
+        internal
+        returns (uint40 tokenId_)
+    {
+        _requireBackend();
+        tokenId_ = _mintFiatTicket(_ticketId, _buyer, _amount, _paymentId);
+    }
+
+    /// @notice EIP-712 voucher redemption path. Anyone (typically the buyer) may submit a backend-signed voucher.
+    function redeemFiatVoucher(FiatVoucher calldata _v, bytes calldata _signature) internal returns (uint40 tokenId_) {
+        _verifyVoucher(_v, _signature);
+        tokenId_ = _mintFiatTicket(_v.ticketId, _v.buyer, _v.amount, _v.paymentId);
+    }
+
+    /// @notice Backend-only batch direct mint. Atomic: any per-item revert rolls back the whole tx.
+    function batchMintFiatTickets(
+        uint64[] calldata _ticketIds,
+        address[] calldata _buyers,
+        uint256[] calldata _amounts,
+        bytes32[] calldata _paymentIds
+    ) internal returns (uint40[] memory tokenIds_) {
+        _requireBackend();
+        uint256 n = _ticketIds.length;
+        if (n == 0 || n != _buyers.length || n != _amounts.length || n != _paymentIds.length) {
+            revert BatchLengthMismatch();
+        }
+        tokenIds_ = new uint40[](n);
+        for (uint256 i; i < n; ++i) {
+            tokenIds_[i] = _mintFiatTicket(_ticketIds[i], _buyers[i], _amounts[i], _paymentIds[i]);
+        }
+    }
+
+    /// @notice Batch voucher redemption. Anyone may submit. Each voucher verified independently. Atomic.
+    function batchRedeemFiatVouchers(FiatVoucher[] calldata _vouchers, bytes[] calldata _signatures)
+        internal
+        returns (uint40[] memory tokenIds_)
+    {
+        uint256 n = _vouchers.length;
+        if (n == 0 || n != _signatures.length) revert BatchLengthMismatch();
+        tokenIds_ = new uint40[](n);
+        for (uint256 i; i < n; ++i) {
+            _verifyVoucher(_vouchers[i], _signatures[i]);
+            tokenIds_[i] =
+                _mintFiatTicket(_vouchers[i].ticketId, _vouchers[i].buyer, _vouchers[i].amount, _vouchers[i].paymentId);
+        }
+    }
+
+    /// @notice Owner-only setter for the trusted backend address. `address(0)` disables both fiat paths.
+    function setTrustedBackend(address _backend) internal onlyOwner {
+        address prev = marketplaceStorage().trustedBackend;
+        marketplaceStorage().trustedBackend = _backend;
+        emit TrustedBackendUpdated(prev, _backend);
     }
 
     //*//////////////////////////////////////////////////////////////////////////
@@ -423,6 +515,112 @@ library MarketplaceLib {
     function getHostItFee(uint256 _fee) internal pure returns (uint256) {
         // {tok} = ({tok} * BPS{1}) / BPS{1}
         return ((_fee * HOSTIT_FEE_BPS) / FEE_BASIS_POINTS);
+    }
+
+    //*//////////////////////////////////////////////////////////////////////////
+    //                          FIAT PAYMENT — VIEW FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*//
+
+    function getTrustedBackend() internal view returns (address) {
+        return marketplaceStorage().trustedBackend;
+    }
+
+    function isFiatPaidToken(uint64 _ticketId, uint40 _tokenId) internal view returns (bool) {
+        return marketplaceStorage().isFiatPaidToken[_ticketId][_tokenId];
+    }
+
+    function isFiatPaymentIdUsed(bytes32 _paymentId) internal view returns (bool) {
+        return marketplaceStorage().usedFiatPaymentIds[_paymentId];
+    }
+
+    /// @return {fiat}
+    function getTicketFiatRevenue(uint64 _ticketId) internal view returns (uint256) {
+        return marketplaceStorage().ticketFiatRevenue[_ticketId];
+    }
+
+    function getFiatDomainSeparator() internal view returns (bytes32) {
+        return _domainSeparator();
+    }
+
+    function hashFiatVoucher(FiatVoucher calldata _v) internal pure returns (bytes32) {
+        return _structHash(_v);
+    }
+
+    //*//////////////////////////////////////////////////////////////////////////
+    //                           PRIVATE HELPER FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*//
+
+    /// @dev Shared pre-mint validation for both crypto and fiat paths. Reads `ITicket.balanceOf` to fail fast
+    ///      before any payment is moved.
+    function _preMintChecks(uint64 _ticketId, address _buyer) private view returns (ExtraTicketData memory td_) {
+        FactoryLib.checkTicketExists(_ticketId);
+        td_ = FactoryLib.getExtraTicketData(_ticketId);
+        uint48 time = SafeCastLib.toUint48(block.timestamp); // {s}
+        if (td_.soldTickets == td_.maxTickets) revert TicketSoldOut(); // {ticket} == {ticket}
+        if (time < td_.purchaseStartTime) revert PurchaseTimeNotReached(); // {s} < {s}
+        if (time > td_.endTime) revert PurchaseTimeNotReached(); // {s} > {s}
+        if (ITicket(td_.ticketAddress).balanceOf(_buyer) >= td_.maxTicketsPerUser) {
+            revert MaxTicketsHeld(); // {ticket} >= {ticket}
+        }
+    }
+
+    /// @dev Shared post-mint accounting for both crypto and fiat paths.
+    function _finalizeMint(ExtraTicketData memory _td, address _buyer, FeeType _feeType, uint256 _totalFee)
+        private
+        returns (uint40 tokenId_)
+    {
+        tokenId_ = SafeCastLib.toUint40(ITicket(_td.ticketAddress).mint(_buyer)); // {ticket}
+        ++FactoryLib.factoryStorage().ticketIdToData[_td.id].soldTickets; // {ticket}
+        if (tokenId_ != FactoryLib.factoryStorage().ticketIdToData[_td.id].soldTickets) {
+            revert TicketAccountingMismatch();
+        }
+        emit TicketMinted(_td.id, _feeType, _totalFee, tokenId_);
+    }
+
+    /// @dev Core fiat mint funnel used by all four entry points. No tokens moved; HostIt's fiat share is
+    ///      reconciled entirely off-chain and is intentionally NOT accumulated in `hostItBalance[FIAT]`.
+    function _mintFiatTicket(uint64 _ticketId, address _buyer, uint256 _amount, bytes32 _paymentId)
+        private
+        returns (uint40 tokenId_)
+    {
+        MarketplaceStorage storage ms = marketplaceStorage();
+        if (_paymentId == bytes32(0)) revert InvalidPaymentId();
+        if (ms.usedFiatPaymentIds[_paymentId]) revert PaymentIdAlreadyUsed(_paymentId);
+        if (_amount == 0) revert ZeroFiatAmount();
+        ms.usedFiatPaymentIds[_paymentId] = true;
+
+        ExtraTicketData memory td = _preMintChecks(_ticketId, _buyer);
+        if (td.isFree) revert TicketIsFree();
+
+        tokenId_ = _finalizeMint(td, _buyer, FeeType.FIAT, _amount);
+        ms.isFiatPaidToken[_ticketId][tokenId_] = true;
+        ms.ticketFiatRevenue[_ticketId] += _amount; // {fiat} += {fiat}
+
+        emit FiatTicketMinted(_ticketId, _buyer, tokenId_, _amount, _paymentId);
+    }
+
+    function _requireBackend() private view {
+        address trusted = marketplaceStorage().trustedBackend;
+        if (trusted == address(0) || msg.sender != trusted) revert UnauthorizedBackend();
+    }
+
+    function _verifyVoucher(FiatVoucher calldata _v, bytes calldata _signature) private view {
+        if (block.timestamp > _v.expiresAt) revert VoucherExpired();
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), _structHash(_v)));
+        address signer = ECDSA.recover(digest, _signature);
+        address trusted = marketplaceStorage().trustedBackend;
+        if (trusted == address(0) || signer != trusted) revert InvalidVoucherSignature();
+    }
+
+    function _domainSeparator() private view returns (bytes32) {
+        return keccak256(
+            abi.encode(EIP712_DOMAIN_TYPEHASH, EIP712_NAME_HASH, EIP712_VERSION_HASH, block.chainid, address(this))
+        );
+    }
+
+    function _structHash(FiatVoucher calldata _v) private pure returns (bytes32) {
+        return
+            keccak256(abi.encode(FIAT_VOUCHER_TYPEHASH, _v.ticketId, _v.buyer, _v.amount, _v.paymentId, _v.expiresAt));
     }
 
     //*//////////////////////////////////////////////////////////////////////////

--- a/src/libs/MarketplaceLib.sol
+++ b/src/libs/MarketplaceLib.sol
@@ -46,10 +46,8 @@ error TicketNotOwned(uint256);
 error InsufficientPayment(FeeType, uint256);
 error PaymentFailed(FeeType, uint256);
 error TicketAccountingMismatch();
-error TicketUnpauseFailed();
 error CreateERC6551AccountFailed();
 error InvalidHostItFeeBps();
-error TicketTransferFailed();
 
 // keccak256(abi.encode(uint256(keccak256("host.it.ticket.marketplace.storage")) - 1)) & ~bytes32(uint256(0xff))
 bytes32 constant MARKETPLACE_STORAGE_LOCATION = 0x3f09c55b469305b27ecae2a46b3f364669f622316549d801837d9eeba9778d00;
@@ -226,10 +224,7 @@ library MarketplaceLib {
         uint256 ticketFee = getTicketFee(_ticketId, _feeType); // {tok}
         marketplaceStorage().ticketBalance[_ticketId][_feeType] -= ticketFee; // {tok} -= {tok}
 
-        try ticket.safeTransferFrom(caller, ticketData.ticketAdmin, _tokenId) {}
-        catch {
-            revert TicketTransferFailed();
-        }
+        ticket.refundTicket(ticketData.ticketAdmin, _tokenId);
 
         if (_feeType == FeeType.ETH) {
             SafeTransferLib.safeTransferETH(_to, ticketFee);
@@ -266,14 +261,6 @@ library MarketplaceLib {
             SafeTransferLib.safeTransferETH(_to, balance);
         } else {
             SafeTransferLib.safeTransfer(getFeeTokenAddress(_feeType), _to, balance);
-        }
-
-        ITicket ticket = ITicket(ticketData.ticketAddress);
-        if (ticket.paused()) {
-            try ticket.unpause() {}
-            catch {
-                revert TicketUnpauseFailed();
-            }
         }
 
         emit TicketBalanceWithdrawn(_ticketId, _feeType, balance, _to);

--- a/src/libs/Ticket.sol
+++ b/src/libs/Ticket.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.30;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import {
     ERC721EnumerableUpgradeable
@@ -10,7 +9,6 @@ import {
 import {
     ERC721RoyaltyUpgradeable
 } from "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721RoyaltyUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
@@ -37,41 +35,36 @@ import {ITicket} from "@ticket/interfaces/ITicket.sol";
 /// @title Ticket
 /// @notice ERC721 Ticket Implementation
 /// @author HostIt Protocol
-contract Ticket is
-    ERC721EnumerableUpgradeable,
-    ERC721RoyaltyUpgradeable,
-    PausableUpgradeable,
-    OwnableUpgradeable,
-    UUPSUpgradeable,
-    ITicket
-{
+contract Ticket is ERC721EnumerableUpgradeable, ERC721RoyaltyUpgradeable, OwnableUpgradeable, ITicket {
     //*//////////////////////////////////////////////////////////////////////////
     //                                  STORAGE
     //////////////////////////////////////////////////////////////////////////*//
 
-    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ERC721URI")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant ERC721_URI_LOCATION = 0x9faa092706460340520342296a39ef71008484de7dbcf27f804dae6b9b4ddd00;
+    // keccak256(abi.encode(uint256(keccak256("host.it.ticket.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant TICKET_STORAGE_LOCATION =
+        0x9faa092706460340520342296a39ef71008484de7dbcf27f804dae6b9b4ddd00;
 
     // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ERC721")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant ERC721_LOCATION = 0x80bb2b638cc20bc4d0a60d66940f3ab4a00c1d7b313497ca82fb0b4ab0079300;
+    bytes32 private constant ERC721_STORAGE_LOCATION =
+        0x80bb2b638cc20bc4d0a60d66940f3ab4a00c1d7b313497ca82fb0b4ab0079300;
 
-    /// @custom:storage-location erc7201:openzeppelin.storage.ERC721URI
-    /// forge-lint: disable-next-line(pascal-case-struct)
-    struct ERC721URIStorage {
+    /// @custom:storage-location erc7201:host.it.ticket.storage
+    struct TicketStorage {
         string _uri;
+        mapping(uint256 tokenId => bool) _used;
     }
 
     /// @dev Internal function to retrieve the storage location of the ERC721URIStorage struct
-    function _getErc721UriStorage() private pure returns (ERC721URIStorage storage $) {
+    function _getTicketStorage() internal pure returns (TicketStorage storage $) {
         assembly {
-            $.slot := ERC721_URI_LOCATION
+            $.slot := TICKET_STORAGE_LOCATION
         }
     }
 
     /// @dev Internal function to retrieve the storage location of the ERC721Storage struct
-    function _getErc721Storage() private pure returns (ERC721Storage storage $) {
+    function _getErc721Storage() internal pure returns (ERC721Storage storage $) {
         assembly {
-            $.slot := ERC721_LOCATION
+            $.slot := ERC721_STORAGE_LOCATION
         }
     }
 
@@ -91,10 +84,12 @@ contract Ticket is
     /// @param _uri The URI of the NFT collection
     function initialize(address _owner, string calldata _name, string calldata _symbol, string calldata _uri)
         public
+        virtual
         initializer
     {
-        string memory symbol = bytes(_symbol).length != 0 ? _symbol : "TICKET";
-        __ERC721_init(_name, symbol);
+        if (bytes(_name).length == 0) revert NameCannotBeEmpty();
+        string memory __symbol = bytes(_symbol).length != 0 ? _symbol : "TICKET";
+        __ERC721_init(_name, __symbol);
         __ERC721Enumerable_init();
         __ERC721Royalty_init();
         __Ownable_init(_owner);
@@ -102,7 +97,7 @@ contract Ticket is
         // Set default royalty to 5%
         _setDefaultRoyalty(_owner, 500);
 
-        _getErc721UriStorage()._uri = _uri;
+        _getTicketStorage()._uri = _uri;
     }
 
     //*//////////////////////////////////////////////////////////////////////////
@@ -127,7 +122,7 @@ contract Ticket is
     /// @param __baseUri The URI to assign
     /// forge-lint: disable-next-line(mixed-case-function)
     function updateURI(string calldata __baseUri) external onlyOwner {
-        _getErc721UriStorage()._uri = __baseUri;
+        _getTicketStorage()._uri = __baseUri;
         emit BaseURIUpdated(__baseUri);
     }
 
@@ -140,16 +135,19 @@ contract Ticket is
         _safeMint(_to, tokenId_);
     }
 
-    /// @notice Pauses token transfers
-    /// @dev This function is used to pause token transfers apart from minting
-    function pause() external onlyOwner {
-        _pause();
+    /// @notice Marks a ticket as used
+    /// @param _tokenId The ID of the ticket to use
+    function useTicket(uint256 _tokenId) external onlyOwner {
+        _requireOwned(_tokenId);
+        _getTicketStorage()._used[_tokenId] = true;
+        emit TicketUsed(_tokenId);
     }
 
-    /// @notice Unpauses token transfers
-    /// @dev This function is used to unpause token transfers apart from minting
-    function unpause() external onlyOwner {
-        _unpause();
+    /// @notice Refunds a ticket
+    /// @param _to The address to send refunded ticket
+    /// @param _tokenId The ID of the ticket to refund
+    function refundTicket(address _to, uint256 _tokenId) external onlyOwner {
+        _update(_to, _tokenId, address(0));
     }
 
     //*//////////////////////////////////////////////////////////////////////////
@@ -157,40 +155,34 @@ contract Ticket is
     //////////////////////////////////////////////////////////////////////////*//
 
     /// @notice Transfers the token from one address to another
-    /// @param from The address to transfer the token from
-    /// @param to The address to transfer the token to
-    /// @param tokenId The ID of the token to transfer
+    /// @param _from The address to transfer the token from
+    /// @param _to The address to transfer the token to
+    /// @param _tokenId The ID of the token to transfer
     /// forge-lint: disable-next-item(erc20-unchecked-transfer)
-    function transferFrom(address from, address to, uint256 tokenId)
+    function transferFrom(address _from, address _to, uint256 _tokenId)
         public
         override(IERC721, ERC721Upgradeable)
-        whenNotPaused
+        onlyUnused(_tokenId)
     {
-        super.transferFrom(from, to, tokenId);
+        super.transferFrom(_from, _to, _tokenId);
     }
 
     /// @notice Transfers the token from one address to another
-    /// @param from The address to transfer the token from
-    /// @param to The address to transfer the token to
-    /// @param tokenId The ID of the token to transfer
-    /// @param data Data to send with the transfer
-    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data)
+    /// @param _from The address to transfer the token from
+    /// @param _to The address to transfer the token to
+    /// @param _tokenId The ID of the token to transfer
+    /// @param _data Data to send with the transfer
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes memory _data)
         public
         override(IERC721, ERC721Upgradeable)
-        whenNotPaused
+        onlyUnused(_tokenId)
     {
-        super.safeTransferFrom(from, to, tokenId, data);
+        super.safeTransferFrom(_from, _to, _tokenId, _data);
     }
 
     //*//////////////////////////////////////////////////////////////////////////
     //                               VIEW FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*//
-
-    /// @notice Returns whether the contract is paused
-    /// @return Whether the contract is paused
-    function paused() public view override(ITicket, PausableUpgradeable) returns (bool) {
-        return PausableUpgradeable.paused();
-    }
 
     /// @notice Returns the metadata URI for the TicketNFT
     /// @dev This function returns the base URI set for the NFT collection, which is used
@@ -215,6 +207,13 @@ contract Ticket is
         return _baseURI();
     }
 
+    /// @notice Checks if a token has been used
+    /// @param _tokenId The ID of the token to check
+    /// @return True if the token has been used, false otherwise
+    function isUsed(uint256 _tokenId) public view returns (bool) {
+        return _getTicketStorage()._used[_tokenId];
+    }
+
     /// @notice Returns whether a given interface is supported by the contract
     /// @param _interfaceId The interface ID to check
     /// @return Whether the interface is supported
@@ -236,7 +235,7 @@ contract Ticket is
     /// @return The base URI for the NFT collection
     /// forge-lint: disable-next-line(mixed-case-function)
     function _baseURI() internal view override returns (string memory) {
-        return _getErc721UriStorage()._uri;
+        return _getTicketStorage()._uri;
     }
 
     /// @dev Internal override for token transfer logic
@@ -253,15 +252,21 @@ contract Ticket is
     }
 
     /// @dev Internal override for increasing balance
-    /// @param account The address to increase the balance for
-    /// @param amount The amount to increase the balance by
-    function _increaseBalance(address account, uint128 amount)
+    /// @param _account The address to increase the balance for
+    /// @param _amount The amount to increase the balance by
+    function _increaseBalance(address _account, uint128 _amount)
         internal
         override(ERC721Upgradeable, ERC721EnumerableUpgradeable)
     {
-        ERC721EnumerableUpgradeable._increaseBalance(account, amount);
+        ERC721EnumerableUpgradeable._increaseBalance(_account, _amount);
     }
 
-    /// @dev Internal override for upgrade logic
-    function _authorizeUpgrade(address) internal override onlyOwner {}
+    //*//////////////////////////////////////////////////////////////////////////
+    //                                  MODIFIER
+    //////////////////////////////////////////////////////////////////////////*//
+
+    modifier onlyUnused(uint256 _tokenId) {
+        if (isUsed(_tokenId)) revert TicketAlreadyUsed();
+        _;
+    }
 }

--- a/test/CheckIn.t.sol
+++ b/test/CheckIn.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.30;
 
 import {DeployedHostItTickets} from "@ticket-test/states/DeployedHostItTickets.sol";
 import {AddressZeroAdmin, FullTicketData, NoAdmins} from "@ticket/libs/FactoryLib.sol";
+import {FeeType} from "@ticket/libs/MarketplaceLib.sol";
 /// forge-lint: disable-next-line(unaliased-plain-import)
 import "@ticket/libs/CheckInLib.sol";
 
@@ -11,68 +12,68 @@ contract CheckInTest is DeployedHostItTickets {
         (uint64 ticketId, uint40 tokenId) = _mintTicketFree();
         vm.warp(1 days + 1);
         vm.expectEmit(true, true, true, true, hostIt);
-        emit CheckedIn(ticketId, alice, tokenId);
-        checkInFacet.checkIn(ticketId, alice, tokenId);
+        emit CheckedIn(ticketId, alice, 0, tokenId);
+        checkInFacet.checkIn(ticketId, tokenId);
         assertTrue(checkInFacet.isCheckedIn(ticketId, alice));
         assertTrue(checkInFacet.isCheckedInForDay(ticketId, 0, alice));
         vm.warp(block.timestamp + 1 days);
         vm.expectEmit(true, true, true, true, hostIt);
-        emit CheckedIn(ticketId, alice, tokenId);
-        checkInFacet.checkIn(ticketId, alice, tokenId);
+        emit CheckedIn(ticketId, alice, 1, tokenId);
+        checkInFacet.checkIn(ticketId, tokenId);
         assertTrue(checkInFacet.isCheckedIn(ticketId, alice));
         assertTrue(checkInFacet.isCheckedInForDay(ticketId, 1, alice));
     }
 
     function test_addTicketAdmins() public {
-        (uint64 ticketId,) = _mintTicketFree();
+        (uint64 ticketId, uint40 tokenId) = _mintTicketFree();
         address[] memory admins = new address[](2);
         admins[0] = bob;
         admins[1] = charlie;
         factoryFacet.addTicketAdmins(ticketId, admins);
         vm.warp(1 days + 1);
         vm.prank(bob);
-        checkInFacet.checkIn(ticketId, alice, 1);
+        checkInFacet.checkIn(ticketId, tokenId);
         assertTrue(checkInFacet.isCheckedIn(ticketId, alice));
         assertTrue(checkInFacet.isCheckedInForDay(ticketId, 0, alice));
         vm.warp(block.timestamp + 1 days);
         vm.prank(charlie);
-        checkInFacet.checkIn(ticketId, alice, 1);
+        checkInFacet.checkIn(ticketId, tokenId);
         assertTrue(checkInFacet.isCheckedIn(ticketId, alice));
         assertTrue(checkInFacet.isCheckedInForDay(ticketId, 1, alice));
     }
 
     function test_removeTicketAdmins() public {
-        (uint64 ticketId,) = _mintTicketFree();
+        (uint64 ticketId, uint40 tokenId) = _mintTicketFree();
         address[] memory admins = new address[](1);
         admins[0] = bob;
         factoryFacet.addTicketAdmins(ticketId, admins);
         vm.warp(1 days + 1);
         vm.prank(bob);
-        checkInFacet.checkIn(ticketId, alice, 1);
+        checkInFacet.checkIn(ticketId, tokenId);
         factoryFacet.removeTicketAdmins(ticketId, admins);
         vm.warp(block.timestamp + 1 days);
         vm.prank(bob);
         vm.expectRevert();
-        checkInFacet.checkIn(ticketId, alice, 1);
+        checkInFacet.checkIn(ticketId, tokenId);
     }
 
     // ======================================================================
     //                        REVERT TESTS
     // ======================================================================
 
-    function test_checkIn_revertsNotTicketOwner() public {
+    function test_checkIn_revertsNonexistentToken() public {
         (uint64 ticketId,) = _mintTicketFree();
         vm.warp(1 days + 1);
-        vm.expectRevert(abi.encodeWithSelector(NotTicketOwner.selector, uint40(1)));
-        checkInFacet.checkIn(ticketId, bob, 1);
+        vm.expectRevert();
+        checkInFacet.checkIn(ticketId, 999);
     }
 
     function test_checkIn_revertsAlreadyCheckedInForDay() public {
         (uint64 ticketId, uint40 tokenId) = _mintTicketFree();
         vm.warp(1 days + 1);
-        checkInFacet.checkIn(ticketId, alice, tokenId);
+        checkInFacet.checkIn(ticketId, tokenId);
         vm.expectRevert(abi.encodeWithSelector(AlreadyCheckedInForDay.selector, uint8(0)));
-        checkInFacet.checkIn(ticketId, alice, tokenId);
+        checkInFacet.checkIn(ticketId, tokenId);
     }
 
     function test_addTicketAdmins_revertsNoAdmins() public {
@@ -129,13 +130,13 @@ contract CheckInTest is DeployedHostItTickets {
         vm.warp(1 days + 1);
         vm.prank(alice);
         vm.expectRevert();
-        checkInFacet.checkIn(ticketId, alice, tokenId);
+        checkInFacet.checkIn(ticketId, tokenId);
     }
 
     function test_getCheckedIn() public {
         (uint64 ticketId, uint40 tokenId) = _mintTicketFree();
         vm.warp(1 days + 1);
-        checkInFacet.checkIn(ticketId, alice, tokenId);
+        checkInFacet.checkIn(ticketId, tokenId);
         address[] memory checkedIn = checkInFacet.getCheckedIn(ticketId);
         assertEq(checkedIn.length, 1);
         assertEq(checkedIn[0], alice);
@@ -144,7 +145,7 @@ contract CheckInTest is DeployedHostItTickets {
     function test_getCheckedInForDay() public {
         (uint64 ticketId, uint40 tokenId) = _mintTicketFree();
         vm.warp(1 days + 1);
-        checkInFacet.checkIn(ticketId, alice, tokenId);
+        checkInFacet.checkIn(ticketId, tokenId);
         address[] memory checkedIn = checkInFacet.getCheckedInForDay(ticketId, 0);
         assertEq(checkedIn.length, 1);
         assertEq(checkedIn[0], alice);
@@ -160,6 +161,58 @@ contract CheckInTest is DeployedHostItTickets {
     }
 
     // ======================================================================
+    //                          BATCH TESTS
+    // ======================================================================
+
+    function test_checkInBatch_happyPath() public {
+        (uint64 ticketId, uint40 aliceToken) = _mintTicketFree();
+        uint40 bobToken = marketplaceFacet.mintTicket(ticketId, FeeType.NONE, bob);
+
+        vm.warp(1 days + 1);
+
+        uint40[] memory tokenIds = new uint40[](2);
+        tokenIds[0] = aliceToken;
+        tokenIds[1] = bobToken;
+        checkInFacet.checkInBatch(ticketId, tokenIds);
+
+        assertTrue(checkInFacet.isCheckedIn(ticketId, alice));
+        assertTrue(checkInFacet.isCheckedIn(ticketId, bob));
+        assertTrue(checkInFacet.isCheckedInForDay(ticketId, 0, alice));
+        assertTrue(checkInFacet.isCheckedInForDay(ticketId, 0, bob));
+    }
+
+    function test_checkInBatch_revertsEmpty() public {
+        (uint64 ticketId,) = _mintTicketFree();
+        vm.warp(1 days + 1);
+        uint40[] memory tokenIds = new uint40[](0);
+        vm.expectRevert(EmptyBatch.selector);
+        checkInFacet.checkInBatch(ticketId, tokenIds);
+    }
+
+    function test_checkInBatch_revertsNonAdmin() public {
+        (uint64 ticketId, uint40 tokenId) = _mintTicketFree();
+        vm.warp(1 days + 1);
+        uint40[] memory tokenIds = new uint40[](1);
+        tokenIds[0] = tokenId;
+        vm.prank(alice);
+        vm.expectRevert();
+        checkInFacet.checkInBatch(ticketId, tokenIds);
+    }
+
+    function test_checkInBatch_revertsDuplicateOwnerSameDay() public {
+        (uint64 ticketId, uint40 tokenId) = _mintTicketFree();
+
+        vm.warp(1 days + 1);
+
+        // Same tokenId twice -> same owner -> day set rejects second add
+        uint40[] memory tokenIds = new uint40[](2);
+        tokenIds[0] = tokenId;
+        tokenIds[1] = tokenId;
+        vm.expectRevert(abi.encodeWithSelector(AlreadyCheckedInForDay.selector, uint8(0)));
+        checkInFacet.checkInBatch(ticketId, tokenIds);
+    }
+
+    // ======================================================================
     //                           FUZZ TESTS
     // ======================================================================
 
@@ -172,7 +225,7 @@ contract CheckInTest is DeployedHostItTickets {
         dayOffset = bound(dayOffset, 0, eventDuration - 1);
 
         vm.warp(ftd.startTime + dayOffset);
-        checkInFacet.checkIn(ticketId, alice, tokenId);
+        checkInFacet.checkIn(ticketId, tokenId);
 
         uint8 expectedDay = uint8(dayOffset / 1 days);
         assertTrue(checkInFacet.isCheckedIn(ticketId, alice));
@@ -187,7 +240,7 @@ contract CheckInTest is DeployedHostItTickets {
         vm.warp(warpTo);
 
         vm.expectRevert(TicketUsePeriodNotStarted.selector);
-        checkInFacet.checkIn(ticketId, alice, tokenId);
+        checkInFacet.checkIn(ticketId, tokenId);
     }
 
     function testFuzz_checkIn_revertsAfterEnd(uint256 extraTime) public {
@@ -198,13 +251,13 @@ contract CheckInTest is DeployedHostItTickets {
         vm.warp(ftd.endTime + extraTime);
 
         vm.expectRevert(TicketUsePeriodHasEnded.selector);
-        checkInFacet.checkIn(ticketId, alice, tokenId);
+        checkInFacet.checkIn(ticketId, tokenId);
     }
 
     function testFuzz_addTicketAdmins(uint8 adminCount) public {
         adminCount = uint8(bound(adminCount, 1, 20));
 
-        (uint64 ticketId,) = _mintTicketFree();
+        (uint64 ticketId, uint40 tokenId) = _mintTicketFree();
 
         address[] memory admins = new address[](adminCount);
         for (uint8 i; i < adminCount; ++i) {
@@ -216,7 +269,7 @@ contract CheckInTest is DeployedHostItTickets {
         // Each admin can check in
         vm.warp(1 days + 1);
         vm.prank(admins[0]);
-        checkInFacet.checkIn(ticketId, alice, 1);
+        checkInFacet.checkIn(ticketId, tokenId);
         assertTrue(checkInFacet.isCheckedIn(ticketId, alice));
     }
 }

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -213,7 +213,7 @@ contract FactoryTest is DeployedHostItTickets {
     function test_createPaidTicket_revertsArrayLengthMismatch() public {
         TicketData memory td = _getPaidTicketData();
         FeeType[] memory feeTypes = new FeeType[](2);
-        feeTypes[0] = FeeType.ETH;
+        feeTypes[0] = FeeType.NATIVE;
         feeTypes[1] = FeeType.USDT;
         uint256[] memory fees = new uint256[](1);
         fees[0] = ETH_FEE;
@@ -224,10 +224,10 @@ contract FactoryTest is DeployedHostItTickets {
     function test_createPaidTicket_revertsZeroFee() public {
         TicketData memory td = _getPaidTicketData();
         FeeType[] memory feeTypes = new FeeType[](1);
-        feeTypes[0] = FeeType.ETH;
+        feeTypes[0] = FeeType.NATIVE;
         uint256[] memory fees = new uint256[](1);
         fees[0] = 0;
-        vm.expectRevert(abi.encodeWithSelector(ZeroFee.selector, FeeType.ETH));
+        vm.expectRevert(abi.encodeWithSelector(ZeroFee.selector, FeeType.NATIVE));
         factoryFacet.createTicket(td, feeTypes, fees);
     }
 

--- a/test/Marketplace.t.sol
+++ b/test/Marketplace.t.sol
@@ -12,6 +12,17 @@ import "@ticket/libs/MarketplaceLib.sol";
 import "@ticket/libs/MarketplaceLib.sol";
 
 contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
+    uint256 internal constant BACKEND_PK = 0xB1AC;
+    uint256 internal constant ATTACKER_PK = 0xBADBAD;
+    address internal backend;
+
+    function setUp() public override {
+        super.setUp();
+        backend = vm.addr(BACKEND_PK);
+        vm.label(backend, "BACKEND");
+        marketplaceFacet.setTrustedBackend(backend);
+    }
+
     // ======================================================================
     //                        FREE TICKET MINTING
     // ======================================================================
@@ -1022,4 +1033,548 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
     }
 
     receive() external payable {}
+
+    // ======================================================================
+    //                    FIAT PAYMENT — HELPERS
+    // ======================================================================
+
+    function _voucher(uint64 ticketId, address buyer, uint256 amount, bytes32 paymentId, uint48 expiresAt)
+        internal
+        pure
+        returns (FiatVoucher memory)
+    {
+        return
+            FiatVoucher({ticketId: ticketId, buyer: buyer, amount: amount, paymentId: paymentId, expiresAt: expiresAt});
+    }
+
+    function _signVoucher(FiatVoucher memory v, uint256 pk) internal view returns (bytes memory) {
+        bytes32 domain = marketplaceFacet.getFiatDomainSeparator();
+        bytes32 structHash = marketplaceFacet.hashFiatVoucher(v);
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domain, structHash));
+        (uint8 vv, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(r, s, vv);
+    }
+
+    function _sign(FiatVoucher memory v) internal view returns (bytes memory) {
+        return _signVoucher(v, BACKEND_PK);
+    }
+
+    function _createFiatTicket() internal returns (uint64) {
+        // Reuse the standard paid ticket data; crypto fees still configured but unused by fiat path.
+        _createPaidTicket();
+        return factoryFacet.ticketCount();
+    }
+
+    function _createRefundableFiatTicket() internal returns (uint64) {
+        TicketData memory td = _getRefundablePaidTicketData();
+        factoryFacet.createTicket(td, _getFeeTypes(), _getFees());
+        return factoryFacet.ticketCount();
+    }
+
+    // ======================================================================
+    //                    FIAT: DIRECT PATH — SINGLE
+    // ======================================================================
+
+    function test_fiat_direct_success() public {
+        uint64 ticketId = _createFiatTicket();
+        bytes32 pid = keccak256("p-1");
+        uint256 amount = 1500;
+
+        vm.prank(backend);
+        vm.expectEmit(true, true, true, true, hostIt);
+        emit TicketMinted(ticketId, FeeType.FIAT, amount, 1);
+        vm.expectEmit(true, true, true, true, hostIt);
+        emit FiatTicketMinted(ticketId, alice, 1, amount, pid);
+        uint40 tokenId = marketplaceFacet.mintFiatTicket(ticketId, alice, amount, pid);
+
+        assertEq(tokenId, 1);
+        assertTrue(marketplaceFacet.isFiatPaidToken(ticketId, tokenId));
+        assertTrue(marketplaceFacet.isFiatPaymentIdUsed(pid));
+        assertEq(marketplaceFacet.getTicketFiatRevenue(ticketId), amount);
+
+        FullTicketData memory ftd = factoryFacet.ticketData(ticketId);
+        assertEq(ITicket(ftd.ticketAddress).ownerOf(tokenId), alice);
+        assertEq(ftd.soldTickets, 1);
+    }
+
+    function test_fiat_direct_revertsNonBackend() public {
+        uint64 ticketId = _createFiatTicket();
+        vm.prank(alice);
+        vm.expectRevert(UnauthorizedBackend.selector);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 100, keccak256("p"));
+    }
+
+    function test_fiat_direct_replayRevertsSamePath() public {
+        uint64 ticketId = _createFiatTicket();
+        bytes32 pid = keccak256("dup");
+        vm.prank(backend);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 100, pid);
+
+        vm.prank(backend);
+        vm.expectRevert(abi.encodeWithSelector(PaymentIdAlreadyUsed.selector, pid));
+        marketplaceFacet.mintFiatTicket(ticketId, bob, 100, pid);
+    }
+
+    function test_fiat_direct_revertsZeroPaymentId() public {
+        uint64 ticketId = _createFiatTicket();
+        vm.prank(backend);
+        vm.expectRevert(InvalidPaymentId.selector);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 100, bytes32(0));
+    }
+
+    function test_fiat_direct_revertsZeroAmount() public {
+        uint64 ticketId = _createFiatTicket();
+        vm.prank(backend);
+        vm.expectRevert(ZeroFiatAmount.selector);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 0, keccak256("p"));
+    }
+
+    function test_fiat_direct_revertsFreeTicket() public {
+        _createFreeTicket();
+        uint64 ticketId = factoryFacet.ticketCount();
+        vm.prank(backend);
+        vm.expectRevert(TicketIsFree.selector);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 100, keccak256("p"));
+    }
+
+    // ======================================================================
+    //                    FIAT: DIRECT PATH — PRE-MINT INVARIANTS
+    // ======================================================================
+
+    function test_fiat_direct_revertsSoldOut() public {
+        TicketData memory td = _getPaidTicketData();
+        td.maxTickets = 1;
+        factoryFacet.createTicket(td, _getFeeTypes(), _getFees());
+        uint64 ticketId = factoryFacet.ticketCount();
+
+        vm.prank(backend);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 100, keccak256("p1"));
+
+        vm.prank(backend);
+        vm.expectRevert(TicketSoldOut.selector);
+        marketplaceFacet.mintFiatTicket(ticketId, bob, 100, keccak256("p2"));
+    }
+
+    function test_fiat_direct_revertsPurchaseTimeNotReached() public {
+        TicketData memory td = _getPaidTicketData();
+        td.purchaseStartTime = uint48(block.timestamp + 1 days);
+        td.startTime = uint48(block.timestamp + 2 days);
+        td.endTime = uint48(block.timestamp + 3 days);
+        factoryFacet.createTicket(td, _getFeeTypes(), _getFees());
+        uint64 ticketId = factoryFacet.ticketCount();
+
+        vm.prank(backend);
+        vm.expectRevert(PurchaseTimeNotReached.selector);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 100, keccak256("p"));
+    }
+
+    function test_fiat_direct_revertsMaxTicketsHeld() public {
+        uint64 ticketId = _createFiatTicket();
+        vm.prank(backend);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 100, keccak256("p1"));
+
+        vm.prank(backend);
+        vm.expectRevert(MaxTicketsHeld.selector);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 100, keccak256("p2"));
+    }
+
+    // ======================================================================
+    //                    FIAT: VOUCHER PATH — SINGLE
+    // ======================================================================
+
+    function test_fiat_voucher_success() public {
+        uint64 ticketId = _createFiatTicket();
+        FiatVoucher memory v = _voucher(ticketId, alice, 250, keccak256("v-1"), uint48(block.timestamp + 1 hours));
+        bytes memory sig = _sign(v);
+
+        vm.prank(charlie); // anyone can submit
+        vm.expectEmit(true, true, true, true, hostIt);
+        emit TicketMinted(ticketId, FeeType.FIAT, 250, 1);
+        vm.expectEmit(true, true, true, true, hostIt);
+        emit FiatTicketMinted(ticketId, alice, 1, 250, v.paymentId);
+        uint40 tokenId = marketplaceFacet.redeemFiatVoucher(v, sig);
+
+        assertEq(tokenId, 1);
+        assertTrue(marketplaceFacet.isFiatPaidToken(ticketId, tokenId));
+        FullTicketData memory ftd = factoryFacet.ticketData(ticketId);
+        assertEq(ITicket(ftd.ticketAddress).ownerOf(tokenId), alice);
+    }
+
+    function test_fiat_voucher_revertsExpired() public {
+        uint64 ticketId = _createFiatTicket();
+        FiatVoucher memory v = _voucher(ticketId, alice, 100, keccak256("v"), uint48(block.timestamp + 1));
+        bytes memory sig = _sign(v);
+
+        vm.warp(v.expiresAt + 1);
+        vm.expectRevert(VoucherExpired.selector);
+        marketplaceFacet.redeemFiatVoucher(v, sig);
+    }
+
+    function test_fiat_voucher_revertsBadSigner() public {
+        uint64 ticketId = _createFiatTicket();
+        FiatVoucher memory v = _voucher(ticketId, alice, 100, keccak256("v"), uint48(block.timestamp + 1 hours));
+        bytes memory sig = _signVoucher(v, ATTACKER_PK);
+
+        vm.expectRevert(InvalidVoucherSignature.selector);
+        marketplaceFacet.redeemFiatVoucher(v, sig);
+    }
+
+    function test_fiat_voucher_revertsTamperedVoucher() public {
+        uint64 ticketId = _createFiatTicket();
+        FiatVoucher memory v = _voucher(ticketId, alice, 100, keccak256("v"), uint48(block.timestamp + 1 hours));
+        bytes memory sig = _sign(v);
+
+        // Tamper: change buyer after signing
+        v.buyer = bob;
+        vm.expectRevert(InvalidVoucherSignature.selector);
+        marketplaceFacet.redeemFiatVoucher(v, sig);
+    }
+
+    function test_fiat_voucher_replayReverts() public {
+        uint64 ticketId = _createFiatTicket();
+        FiatVoucher memory v = _voucher(ticketId, alice, 100, keccak256("v"), uint48(block.timestamp + 1 hours));
+        bytes memory sig = _sign(v);
+        marketplaceFacet.redeemFiatVoucher(v, sig);
+
+        vm.expectRevert(abi.encodeWithSelector(PaymentIdAlreadyUsed.selector, v.paymentId));
+        marketplaceFacet.redeemFiatVoucher(v, sig);
+    }
+
+    function test_fiat_crossPathReplayReverts() public {
+        uint64 ticketId = _createFiatTicket();
+        bytes32 pid = keccak256("cross");
+
+        FiatVoucher memory v = _voucher(ticketId, alice, 100, pid, uint48(block.timestamp + 1 hours));
+        bytes memory sig = _sign(v);
+        marketplaceFacet.redeemFiatVoucher(v, sig);
+
+        vm.prank(backend);
+        vm.expectRevert(abi.encodeWithSelector(PaymentIdAlreadyUsed.selector, pid));
+        marketplaceFacet.mintFiatTicket(ticketId, bob, 100, pid);
+    }
+
+    // ======================================================================
+    //                    FIAT: BATCH — DIRECT
+    // ======================================================================
+
+    function test_fiat_batchDirect_success() public {
+        uint64 ticketId = _createFiatTicket();
+
+        uint64[] memory tids = new uint64[](2);
+        tids[0] = ticketId;
+        tids[1] = ticketId;
+        address[] memory buyers = new address[](2);
+        buyers[0] = alice;
+        buyers[1] = bob;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 100;
+        amounts[1] = 200;
+        bytes32[] memory pids = new bytes32[](2);
+        pids[0] = keccak256("b-1");
+        pids[1] = keccak256("b-2");
+
+        vm.prank(backend);
+        uint40[] memory tokenIds = marketplaceFacet.batchMintFiatTickets(tids, buyers, amounts, pids);
+
+        assertEq(tokenIds.length, 2);
+        assertEq(tokenIds[0], 1);
+        assertEq(tokenIds[1], 2);
+        assertEq(marketplaceFacet.getTicketFiatRevenue(ticketId), 300);
+        assertTrue(marketplaceFacet.isFiatPaidToken(ticketId, 1));
+        assertTrue(marketplaceFacet.isFiatPaidToken(ticketId, 2));
+    }
+
+    function test_fiat_batchDirect_atomicRollback() public {
+        uint64 ticketId = _createFiatTicket();
+        bytes32 dup = keccak256("dup");
+
+        // Pre-consume the dup payment id via single mint.
+        vm.prank(backend);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 100, dup);
+
+        uint64[] memory tids = new uint64[](2);
+        tids[0] = ticketId;
+        tids[1] = ticketId;
+        address[] memory buyers = new address[](2);
+        buyers[0] = bob;
+        buyers[1] = charlie;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 100;
+        amounts[1] = 200;
+        bytes32[] memory pids = new bytes32[](2);
+        bytes32 freshPid = keccak256("fresh");
+        pids[0] = freshPid;
+        pids[1] = dup; // collision on item 2
+
+        vm.prank(backend);
+        vm.expectRevert(abi.encodeWithSelector(PaymentIdAlreadyUsed.selector, dup));
+        marketplaceFacet.batchMintFiatTickets(tids, buyers, amounts, pids);
+
+        // Item 1 must NOT have been persisted (atomic rollback).
+        assertFalse(marketplaceFacet.isFiatPaymentIdUsed(freshPid));
+    }
+
+    function test_fiat_batchDirect_revertsLengthMismatch() public {
+        uint64[] memory tids = new uint64[](1);
+        address[] memory buyers = new address[](2);
+        uint256[] memory amounts = new uint256[](1);
+        bytes32[] memory pids = new bytes32[](1);
+
+        vm.prank(backend);
+        vm.expectRevert(BatchLengthMismatch.selector);
+        marketplaceFacet.batchMintFiatTickets(tids, buyers, amounts, pids);
+    }
+
+    function test_fiat_batchDirect_revertsEmpty() public {
+        uint64[] memory tids = new uint64[](0);
+        address[] memory buyers = new address[](0);
+        uint256[] memory amounts = new uint256[](0);
+        bytes32[] memory pids = new bytes32[](0);
+
+        vm.prank(backend);
+        vm.expectRevert(BatchLengthMismatch.selector);
+        marketplaceFacet.batchMintFiatTickets(tids, buyers, amounts, pids);
+    }
+
+    function test_fiat_batchDirect_revertsNonBackend() public {
+        uint64 ticketId = _createFiatTicket();
+        uint64[] memory tids = new uint64[](1);
+        tids[0] = ticketId;
+        address[] memory buyers = new address[](1);
+        buyers[0] = alice;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
+        bytes32[] memory pids = new bytes32[](1);
+        pids[0] = keccak256("p");
+
+        vm.prank(alice);
+        vm.expectRevert(UnauthorizedBackend.selector);
+        marketplaceFacet.batchMintFiatTickets(tids, buyers, amounts, pids);
+    }
+
+    // ======================================================================
+    //                    FIAT: BATCH — VOUCHER
+    // ======================================================================
+
+    function test_fiat_batchVoucher_success() public {
+        uint64 ticketId = _createFiatTicket();
+        FiatVoucher[] memory vs = new FiatVoucher[](2);
+        vs[0] = _voucher(ticketId, alice, 100, keccak256("bv-1"), uint48(block.timestamp + 1 hours));
+        vs[1] = _voucher(ticketId, bob, 200, keccak256("bv-2"), uint48(block.timestamp + 1 hours));
+        bytes[] memory sigs = new bytes[](2);
+        sigs[0] = _sign(vs[0]);
+        sigs[1] = _sign(vs[1]);
+
+        uint40[] memory tokenIds = marketplaceFacet.batchRedeemFiatVouchers(vs, sigs);
+        assertEq(tokenIds[0], 1);
+        assertEq(tokenIds[1], 2);
+        assertEq(marketplaceFacet.getTicketFiatRevenue(ticketId), 300);
+    }
+
+    function test_fiat_batchVoucher_oneBadSigRollsBack() public {
+        uint64 ticketId = _createFiatTicket();
+        FiatVoucher[] memory vs = new FiatVoucher[](2);
+        vs[0] = _voucher(ticketId, alice, 100, keccak256("bvr-1"), uint48(block.timestamp + 1 hours));
+        vs[1] = _voucher(ticketId, bob, 200, keccak256("bvr-2"), uint48(block.timestamp + 1 hours));
+        bytes[] memory sigs = new bytes[](2);
+        sigs[0] = _sign(vs[0]);
+        sigs[1] = _signVoucher(vs[1], ATTACKER_PK); // bad sig on item 2
+
+        vm.expectRevert(InvalidVoucherSignature.selector);
+        marketplaceFacet.batchRedeemFiatVouchers(vs, sigs);
+
+        assertFalse(marketplaceFacet.isFiatPaymentIdUsed(vs[0].paymentId));
+    }
+
+    function test_fiat_batchVoucher_revertsLengthMismatch() public {
+        FiatVoucher[] memory vs = new FiatVoucher[](1);
+        bytes[] memory sigs = new bytes[](2);
+        vm.expectRevert(BatchLengthMismatch.selector);
+        marketplaceFacet.batchRedeemFiatVouchers(vs, sigs);
+    }
+
+    function test_fiat_batchVoucher_revertsEmpty() public {
+        FiatVoucher[] memory vs = new FiatVoucher[](0);
+        bytes[] memory sigs = new bytes[](0);
+        vm.expectRevert(BatchLengthMismatch.selector);
+        marketplaceFacet.batchRedeemFiatVouchers(vs, sigs);
+    }
+
+    // ======================================================================
+    //                    FIAT: KILL SWITCH (trustedBackend == 0)
+    // ======================================================================
+
+    function test_fiat_killSwitch_disablesDirect() public {
+        marketplaceFacet.setTrustedBackend(address(0));
+        uint64 ticketId = _createFiatTicket();
+        vm.prank(backend);
+        vm.expectRevert(UnauthorizedBackend.selector);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 100, keccak256("p"));
+    }
+
+    function test_fiat_killSwitch_disablesVoucher() public {
+        uint64 ticketId = _createFiatTicket();
+        FiatVoucher memory v = _voucher(ticketId, alice, 100, keccak256("p"), uint48(block.timestamp + 1 hours));
+        bytes memory sig = _sign(v);
+
+        marketplaceFacet.setTrustedBackend(address(0));
+
+        vm.expectRevert(InvalidVoucherSignature.selector);
+        marketplaceFacet.redeemFiatVoucher(v, sig);
+    }
+
+    // ======================================================================
+    //                    FIAT: LEDGER — NO HOSTIT FEE
+    // ======================================================================
+
+    function test_fiat_noHostItFeeAccumulated() public {
+        uint64 ticketId = _createFiatTicket();
+        vm.prank(backend);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 10_000, keccak256("p"));
+
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.FIAT), 0);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.FIAT), 0);
+        // Crypto ledger untouched
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), 0);
+    }
+
+    // ======================================================================
+    //                    GUARDS ON EXISTING CRYPTO PATHS
+    // ======================================================================
+
+    function test_guards_mintTicket_revertsForFIAT() public {
+        uint64 ticketId = _createFiatTicket();
+        vm.expectRevert(FiatFeeTypeNotMintable.selector);
+        marketplaceFacet.mintTicket(ticketId, FeeType.FIAT, alice);
+    }
+
+    function test_guards_updateTicketFees_revertsForFIAT() public {
+        uint64 ticketId = _createFiatTicket();
+        FeeType[] memory fts = new FeeType[](1);
+        fts[0] = FeeType.FIAT;
+        uint256[] memory fs = new uint256[](1);
+        fs[0] = 1000;
+        vm.expectRevert(FiatFeeNotSettable.selector);
+        marketplaceFacet.updateTicketFees(ticketId, fts, fs);
+    }
+
+    function test_guards_updateTicketFees_revertsForFIATInMixedList() public {
+        uint64 ticketId = _createFiatTicket();
+        FeeType[] memory fts = new FeeType[](2);
+        fts[0] = FeeType.NATIVE;
+        fts[1] = FeeType.FIAT;
+        uint256[] memory fs = new uint256[](2);
+        fs[0] = 1e18;
+        fs[1] = 1000;
+        vm.expectRevert(FiatFeeNotSettable.selector);
+        marketplaceFacet.updateTicketFees(ticketId, fts, fs);
+    }
+
+    function test_guards_createTicket_revertsForFIATFee() public {
+        // createTicket → setTicketFees → FiatFeeNotSettable guard fires.
+        TicketData memory td = _getPaidTicketData();
+        FeeType[] memory fts = new FeeType[](1);
+        fts[0] = FeeType.FIAT;
+        uint256[] memory fs = new uint256[](1);
+        fs[0] = 1000;
+        vm.expectRevert(FiatFeeNotSettable.selector);
+        factoryFacet.createTicket(td, fts, fs);
+    }
+
+    function test_guards_claimRefund_revertsForFiatPaidToken() public {
+        uint64 ticketId = _createRefundableFiatTicket();
+        vm.prank(backend);
+        uint40 tokenId = marketplaceFacet.mintFiatTicket(ticketId, alice, 100, keccak256("p"));
+
+        FullTicketData memory ftd = factoryFacet.ticketData(ticketId);
+        vm.warp(ftd.endTime);
+        vm.prank(alice);
+        vm.expectRevert(FiatTicketNotRefundable.selector);
+        marketplaceFacet.claimRefund(ticketId, FeeType.FIAT, tokenId, alice);
+    }
+
+    function test_guards_claimRefund_revertsForFiatTokenEvenWhenFeeTypeNATIVE() public {
+        // A fiat-paid token should be unrefundable regardless of which FeeType the caller passes.
+        uint64 ticketId = _createRefundableFiatTicket();
+        vm.prank(backend);
+        uint40 tokenId = marketplaceFacet.mintFiatTicket(ticketId, alice, 100, keccak256("p"));
+
+        FullTicketData memory ftd = factoryFacet.ticketData(ticketId);
+        vm.warp(ftd.endTime);
+        vm.prank(alice);
+        vm.expectRevert(FiatTicketNotRefundable.selector);
+        marketplaceFacet.claimRefund(ticketId, FeeType.NATIVE, tokenId, alice);
+    }
+
+    function test_guards_withdrawTicketBalance_revertsForFIAT() public {
+        uint64 ticketId = _createFiatTicket();
+        vm.expectRevert(FiatBalanceNotWithdrawable.selector);
+        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.FIAT, withdrawer);
+    }
+
+    function test_guards_withdrawHostItBalance_revertsForFIAT() public {
+        vm.expectRevert(FiatBalanceNotWithdrawable.selector);
+        marketplaceFacet.withdrawHostItBalance(FeeType.FIAT, withdrawer);
+    }
+
+    // ======================================================================
+    //                    OWNER ROTATION
+    // ======================================================================
+
+    function test_setTrustedBackend_revertsNonOwner() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        marketplaceFacet.setTrustedBackend(alice);
+    }
+
+    function test_setTrustedBackend_rotates() public {
+        address newBackend = makeAddr("newBackend");
+        vm.expectEmit(true, true, true, true, hostIt);
+        emit TrustedBackendUpdated(backend, newBackend);
+        marketplaceFacet.setTrustedBackend(newBackend);
+        assertEq(marketplaceFacet.getTrustedBackend(), newBackend);
+
+        // Old backend can no longer call.
+        uint64 ticketId = _createFiatTicket();
+        vm.prank(backend);
+        vm.expectRevert(UnauthorizedBackend.selector);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 100, keccak256("rot"));
+
+        // New backend can.
+        vm.prank(newBackend);
+        marketplaceFacet.mintFiatTicket(ticketId, alice, 100, keccak256("rot"));
+    }
+
+    // ======================================================================
+    //                    EIP-712 SANITY
+    // ======================================================================
+
+    function test_eip712_domainSeparator() public view {
+        bytes32 expected = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes("HostItTickets")),
+                keccak256(bytes("1")),
+                block.chainid,
+                hostIt
+            )
+        );
+        assertEq(marketplaceFacet.getFiatDomainSeparator(), expected);
+    }
+
+    function test_eip712_voucherTypehash() public view {
+        bytes32 expected =
+            keccak256("FiatVoucher(uint64 ticketId,address buyer,uint256 amount,bytes32 paymentId,uint48 expiresAt)");
+        assertEq(marketplaceFacet.getFiatVoucherTypehash(), expected);
+    }
+
+    function test_eip712_structHashMatchesAbiEncode() public view {
+        FiatVoucher memory v = _voucher(7, alice, 1234, keccak256("typehash-check"), uint48(block.timestamp + 1 hours));
+        bytes32 expected = keccak256(
+            abi.encode(
+                marketplaceFacet.getFiatVoucherTypehash(), v.ticketId, v.buyer, v.amount, v.paymentId, v.expiresAt
+            )
+        );
+        assertEq(marketplaceFacet.hashFiatVoucher(v), expected);
+    }
 }

--- a/test/Marketplace.t.sol
+++ b/test/Marketplace.t.sol
@@ -677,20 +677,6 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
     //            WITHDRAW TO CONTRACT REVERTS
     // ======================================================================
 
-    function test_withdrawTicketBalance_revertsContractNotAllowed() public {
-        (uint64 ticketId,,,) = _mintTicketETHRefundable();
-        FullTicketData memory ftd = factoryFacet.ticketData(ticketId);
-        vm.warp(ftd.endTime + marketplaceFacet.getRefundPeriod());
-        vm.expectRevert(ContractNotAllowed.selector);
-        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.NATIVE, hostIt);
-    }
-
-    function test_withdrawHostItBalance_revertsContractNotAllowed() public {
-        _mintTicketETH();
-        vm.expectRevert(ContractNotAllowed.selector);
-        marketplaceFacet.withdrawHostItBalance(FeeType.NATIVE, hostIt);
-    }
-
     function test_withdrawHostItBalance_revertsNonOwner() public {
         _mintTicketETH();
         vm.prank(alice);

--- a/test/Marketplace.t.sol
+++ b/test/Marketplace.t.sol
@@ -28,12 +28,12 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
     function test_mintFreeTicket_noBalanceChanges() public {
         vm.prank(alice);
         (uint64 ticketId,) = _mintTicketFree();
-        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.ETH), 0);
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), 0);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.NATIVE), 0);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), 0);
     }
 
     // ======================================================================
-    //                    NON-REFUNDABLE DIRECT PAYMENT: ETH
+    //                    NON-REFUNDABLE DIRECT PAYMENT: NATIVE
     // ======================================================================
 
     function test_directPayment_ETH_organizerReceivesFee() public {
@@ -49,12 +49,12 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
 
     function test_directPayment_ETH_hostItFeeAccumulated() public {
         (,,, uint256 hostItFee) = _mintTicketETH();
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), hostItFee);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), hostItFee);
     }
 
     function test_directPayment_ETH_noTicketBalanceEscrowed() public {
         (uint64 ticketId,,,) = _mintTicketETH();
-        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.ETH), 0);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.NATIVE), 0);
     }
 
     function test_directPayment_ETH_ticketMintedToBuyer() public {
@@ -74,39 +74,39 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
     function test_directPayment_ETH_emitsTicketMinted() public {
         _createPaidTicket();
         uint64 ticketId = factoryFacet.ticketCount();
-        (,, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.ETH);
+        (,, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.NATIVE);
         hoax(alice, totalFee);
         vm.expectEmit(true, true, true, true, hostIt);
-        emit TicketMinted(ticketId, FeeType.ETH, totalFee, 1);
-        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.ETH, alice);
+        emit TicketMinted(ticketId, FeeType.NATIVE, totalFee, 1);
+        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.NATIVE, alice);
     }
 
     function test_directPayment_ETH_multipleBuyersAccumulateHostItFees() public {
         _createPaidTicket();
         uint64 ticketId = factoryFacet.ticketCount();
-        (, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.ETH);
+        (, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.NATIVE);
 
         hoax(alice, totalFee);
-        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.ETH, alice);
+        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.NATIVE, alice);
 
         hoax(bob, totalFee);
-        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.ETH, bob);
+        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.NATIVE, bob);
 
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), hostItFee * 2);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), hostItFee * 2);
     }
 
     function test_directPayment_ETH_multipleBuyersPayOrganizer() public {
         _createPaidTicket();
         uint64 ticketId = factoryFacet.ticketCount();
-        (uint256 fee,, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.ETH);
+        (uint256 fee,, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.NATIVE);
 
         uint256 ownerBalanceBefore = owner.balance;
 
         hoax(alice, totalFee);
-        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.ETH, alice);
+        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.NATIVE, alice);
 
         hoax(bob, totalFee);
-        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.ETH, bob);
+        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.NATIVE, bob);
 
         assertEq(owner.balance - ownerBalanceBefore, fee * 2);
     }
@@ -114,10 +114,10 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
     function test_directPayment_ETH_revertsInsufficientValue() public {
         _createPaidTicket();
         uint64 ticketId = factoryFacet.ticketCount();
-        (,, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.ETH);
+        (,, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.NATIVE);
         hoax(alice, totalFee);
-        vm.expectRevert(abi.encodeWithSelector(InsufficientPayment.selector, FeeType.ETH, totalFee));
-        marketplaceFacet.mintTicket{value: totalFee - 1}(ticketId, FeeType.ETH, alice);
+        vm.expectRevert(abi.encodeWithSelector(InsufficientPayment.selector, FeeType.NATIVE, totalFee));
+        marketplaceFacet.mintTicket{value: totalFee - 1}(ticketId, FeeType.NATIVE, alice);
     }
 
     // ======================================================================
@@ -233,7 +233,7 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         vm.warp(fullTicketData.endTime);
         vm.prank(alice);
         vm.expectRevert(RefundNotEnabled.selector);
-        marketplaceFacet.claimRefund(ticketId, FeeType.ETH, tokenId, alice);
+        marketplaceFacet.claimRefund(ticketId, FeeType.NATIVE, tokenId, alice);
     }
 
     // ======================================================================
@@ -245,7 +245,7 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         FullTicketData memory fullTicketData = factoryFacet.ticketData(ticketId);
         vm.warp(fullTicketData.endTime + marketplaceFacet.getRefundPeriod());
         vm.expectRevert(InsufficientWithdrawBalance.selector);
-        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.ETH, withdrawer);
+        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.NATIVE, withdrawer);
     }
 
     // ======================================================================
@@ -255,9 +255,9 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
     function test_directPayment_withdrawHostItBalanceETH() public {
         (,,, uint256 hostItFee) = _mintTicketETH();
         vm.expectEmit(true, true, true, true, hostIt);
-        emit HostItBalanceWithdrawn(FeeType.ETH, hostItFee, withdrawer);
-        marketplaceFacet.withdrawHostItBalance(FeeType.ETH, withdrawer);
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), 0);
+        emit HostItBalanceWithdrawn(FeeType.NATIVE, hostItFee, withdrawer);
+        marketplaceFacet.withdrawHostItBalance(FeeType.NATIVE, withdrawer);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), 0);
         assertEq(withdrawer.balance, hostItFee);
     }
 
@@ -281,17 +281,17 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
 
     function test_directPayment_withdrawHostItBalanceRevertsIfZero() public {
         vm.expectRevert(InsufficientWithdrawBalance.selector);
-        marketplaceFacet.withdrawHostItBalance(FeeType.ETH, withdrawer);
+        marketplaceFacet.withdrawHostItBalance(FeeType.NATIVE, withdrawer);
     }
 
     // ======================================================================
-    //                    REFUNDABLE ESCROW: ETH
+    //                    REFUNDABLE ESCROW: NATIVE
     // ======================================================================
 
     function test_refundable_ETH_fundsEscrowed() public {
         (uint64 ticketId,, uint256 fee, uint256 hostItFee) = _mintTicketETHRefundable();
-        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.ETH), fee);
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), hostItFee);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.NATIVE), fee);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), hostItFee);
     }
 
     function test_refundable_ETH_organizerDoesNotReceiveFee() public {
@@ -325,13 +325,13 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         vm.warp(fullTicketData.endTime);
         vm.prank(alice);
         vm.expectEmit(true, true, true, true, hostIt);
-        emit TicketRefunded(ticketId, FeeType.ETH, fee, bob);
-        marketplaceFacet.claimRefund(ticketId, FeeType.ETH, tokenId, bob);
+        emit TicketRefunded(ticketId, FeeType.NATIVE, fee, bob);
+        marketplaceFacet.claimRefund(ticketId, FeeType.NATIVE, tokenId, bob);
 
         assertEq(ticket.ownerOf(tokenId), owner);
         assertEq(bob.balance, fee);
-        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.ETH), 0);
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), hostItFee);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.NATIVE), 0);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), hostItFee);
     }
 
     function test_refundable_ETH_claimRefundRevertsBeforeEndTime() public {
@@ -345,7 +345,7 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         vm.warp(fullTicketData.endTime - 1);
         vm.prank(alice);
         vm.expectRevert(RefundPeriodNotReached.selector);
-        marketplaceFacet.claimRefund(ticketId, FeeType.ETH, tokenId, bob);
+        marketplaceFacet.claimRefund(ticketId, FeeType.NATIVE, tokenId, bob);
     }
 
     function test_refundable_ETH_claimRefundRevertsAfterRefundPeriod() public {
@@ -359,7 +359,7 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         vm.warp(fullTicketData.endTime + marketplaceFacet.getRefundPeriod() + 1);
         vm.prank(alice);
         vm.expectRevert(RefundPeriodExpired.selector);
-        marketplaceFacet.claimRefund(ticketId, FeeType.ETH, tokenId, bob);
+        marketplaceFacet.claimRefund(ticketId, FeeType.NATIVE, tokenId, bob);
     }
 
     function test_refundable_ETH_claimRefundRevertsNonOwner() public {
@@ -369,7 +369,7 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         vm.warp(fullTicketData.endTime);
         vm.prank(bob);
         vm.expectRevert(abi.encodeWithSelector(TicketNotOwned.selector, tokenId));
-        marketplaceFacet.claimRefund(ticketId, FeeType.ETH, tokenId, bob);
+        marketplaceFacet.claimRefund(ticketId, FeeType.NATIVE, tokenId, bob);
     }
 
     function test_refundable_ETH_withdrawTicketBalanceAfterRefundPeriod() public {
@@ -378,10 +378,10 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
 
         vm.warp(fullTicketData.endTime + marketplaceFacet.getRefundPeriod());
         vm.expectEmit(true, true, true, true, hostIt);
-        emit TicketBalanceWithdrawn(ticketId, FeeType.ETH, fee, withdrawer);
-        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.ETH, withdrawer);
+        emit TicketBalanceWithdrawn(ticketId, FeeType.NATIVE, fee, withdrawer);
+        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.NATIVE, withdrawer);
 
-        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.ETH), 0);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.NATIVE), 0);
         assertEq(withdrawer.balance, fee);
     }
 
@@ -391,7 +391,7 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
 
         vm.warp(fullTicketData.endTime + marketplaceFacet.getRefundPeriod() - 1);
         vm.expectRevert(WithdrawPeriodNotReached.selector);
-        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.ETH, withdrawer);
+        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.NATIVE, withdrawer);
     }
 
     // ======================================================================
@@ -507,9 +507,9 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
     function test_refundable_withdrawHostItBalanceETH() public {
         (,,, uint256 hostItFee) = _mintTicketETHRefundable();
         vm.expectEmit(true, true, true, true, hostIt);
-        emit HostItBalanceWithdrawn(FeeType.ETH, hostItFee, withdrawer);
-        marketplaceFacet.withdrawHostItBalance(FeeType.ETH, withdrawer);
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), 0);
+        emit HostItBalanceWithdrawn(FeeType.NATIVE, hostItFee, withdrawer);
+        marketplaceFacet.withdrawHostItBalance(FeeType.NATIVE, withdrawer);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), 0);
         assertEq(withdrawer.balance, hostItFee);
     }
 
@@ -544,7 +544,7 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         fees[1] = USDT_FEE * 2;
         fees[2] = USDC_FEE * 2;
         marketplaceFacet.updateTicketFees(ticketId, feeTypes, fees);
-        assertEq(marketplaceFacet.getTicketFee(ticketId, FeeType.ETH), fees[0]);
+        assertEq(marketplaceFacet.getTicketFee(ticketId, FeeType.NATIVE), fees[0]);
         assertEq(marketplaceFacet.getTicketFee(ticketId, FeeType.USDT), fees[1]);
         assertEq(marketplaceFacet.getTicketFee(ticketId, FeeType.USDC), fees[2]);
     }
@@ -552,7 +552,7 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
     function test_feeCalculation() public {
         _createPaidTicket();
         uint64 ticketId = factoryFacet.ticketCount();
-        (uint256 fee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.ETH);
+        (uint256 fee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.NATIVE);
         assertEq(fee, ETH_FEE);
         assertEq(hostItFee, (ETH_FEE * 300) / 10_000);
         assertEq(totalFee, fee + hostItFee);
@@ -562,8 +562,8 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         _createPaidTicket();
         uint64 ticketId = factoryFacet.ticketCount();
         hoax(alice, 1 ether);
-        vm.expectRevert(abi.encodeWithSelector(FeeNotEnabled.selector, ticketId, FeeType.WETH));
-        marketplaceFacet.mintTicket{value: 1 ether}(ticketId, FeeType.WETH, alice);
+        vm.expectRevert(abi.encodeWithSelector(FeeNotEnabled.selector, ticketId, FeeType.WNATIVE));
+        marketplaceFacet.mintTicket{value: 1 ether}(ticketId, FeeType.WNATIVE, alice);
     }
 
     // ======================================================================
@@ -589,13 +589,9 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         td.maxTicketsPerUser = 1;
         factoryFacet.createTicket(td, _getZeroFeeType(), _getZeroFee());
         uint64 ticketId = factoryFacet.ticketCount();
-        // Mint first ticket (balance becomes 1, check is > maxTicketsPerUser so 1 > 1 = false, ok)
+        // First mint: balance 0 >= 1 is false → succeeds; balance becomes 1.
         marketplaceFacet.mintTicket(ticketId, FeeType.NONE, alice);
-        // Second mint: balance is 1, but then check is 1 > 1 = false. Need to check logic...
-        // Actually the check is: if (ticket.balanceOf(_buyer) > ticketData.maxTicketsPerUser) revert
-        // After first mint, balance = 1. maxTicketsPerUser = 1. 1 > 1 = false. So need to mint again.
-        marketplaceFacet.mintTicket(ticketId, FeeType.NONE, alice);
-        // Now balance = 2. 2 > 1 = true. Revert.
+        // Second mint: balance 1 >= 1 is true → reverts.
         vm.expectRevert(MaxTicketsHeld.selector);
         marketplaceFacet.mintTicket(ticketId, FeeType.NONE, alice);
     }
@@ -632,10 +628,10 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         _createPaidTicket();
         uint64 ticketId = factoryFacet.ticketCount();
         FeeType[] memory feeTypes = new FeeType[](1);
-        feeTypes[0] = FeeType.ETH;
+        feeTypes[0] = FeeType.NATIVE;
         uint256[] memory fees = new uint256[](1);
         fees[0] = 0;
-        vm.expectRevert(abi.encodeWithSelector(ZeroFee.selector, FeeType.ETH));
+        vm.expectRevert(abi.encodeWithSelector(ZeroFee.selector, FeeType.NATIVE));
         marketplaceFacet.updateTicketFees(ticketId, feeTypes, fees);
     }
 
@@ -643,18 +639,18 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         _createPaidTicket();
         uint64 ticketId = factoryFacet.ticketCount();
         FeeType[] memory feeTypes = new FeeType[](1);
-        feeTypes[0] = FeeType.ETH;
+        feeTypes[0] = FeeType.NATIVE;
         uint256[] memory fees = new uint256[](1);
         fees[0] = ETH_FEE * 2;
         marketplaceFacet.updateTicketFees(ticketId, feeTypes, fees);
-        assertEq(marketplaceFacet.getTicketFee(ticketId, FeeType.ETH), ETH_FEE * 2);
+        assertEq(marketplaceFacet.getTicketFee(ticketId, FeeType.NATIVE), ETH_FEE * 2);
     }
 
     function test_updateTicketFees_revertsInvalidFeeConfig() public {
         _createPaidTicket();
         uint64 ticketId = factoryFacet.ticketCount();
         FeeType[] memory feeTypes = new FeeType[](2);
-        feeTypes[0] = FeeType.ETH;
+        feeTypes[0] = FeeType.NATIVE;
         feeTypes[1] = FeeType.USDT;
         uint256[] memory fees = new uint256[](1);
         fees[0] = ETH_FEE;
@@ -686,20 +682,20 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         FullTicketData memory ftd = factoryFacet.ticketData(ticketId);
         vm.warp(ftd.endTime + marketplaceFacet.getRefundPeriod());
         vm.expectRevert(ContractNotAllowed.selector);
-        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.ETH, hostIt);
+        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.NATIVE, hostIt);
     }
 
     function test_withdrawHostItBalance_revertsContractNotAllowed() public {
         _mintTicketETH();
         vm.expectRevert(ContractNotAllowed.selector);
-        marketplaceFacet.withdrawHostItBalance(FeeType.ETH, hostIt);
+        marketplaceFacet.withdrawHostItBalance(FeeType.NATIVE, hostIt);
     }
 
     function test_withdrawHostItBalance_revertsNonOwner() public {
         _mintTicketETH();
         vm.prank(alice);
         vm.expectRevert();
-        marketplaceFacet.withdrawHostItBalance(FeeType.ETH, withdrawer);
+        marketplaceFacet.withdrawHostItBalance(FeeType.NATIVE, withdrawer);
     }
 
     // ======================================================================
@@ -721,7 +717,7 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         // Refundable ticket
         (,,, uint256 hostItFee2) = _mintTicketETHRefundable();
 
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), hostItFee1 + hostItFee2);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), hostItFee1 + hostItFee2);
     }
 
     // ======================================================================
@@ -741,12 +737,12 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         uint64 ticketId = factoryFacet.ticketCount();
 
         FeeType[] memory feeTypes = new FeeType[](1);
-        feeTypes[0] = FeeType.ETH;
+        feeTypes[0] = FeeType.NATIVE;
         uint256[] memory fees = new uint256[](1);
         fees[0] = fee;
         marketplaceFacet.updateTicketFees(ticketId, feeTypes, fees);
 
-        (uint256 ticketFee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.ETH);
+        (uint256 ticketFee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.NATIVE);
         assertEq(ticketFee, fee);
         assertEq(hostItFee, (fee * 300) / 10_000);
         assertEq(totalFee, ticketFee + hostItFee);
@@ -757,24 +753,24 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
 
         TicketData memory td = _getPaidTicketData();
         FeeType[] memory feeTypes = new FeeType[](1);
-        feeTypes[0] = FeeType.ETH;
+        feeTypes[0] = FeeType.NATIVE;
         uint256[] memory fees = new uint256[](1);
         fees[0] = fee;
         factoryFacet.createTicket(td, feeTypes, fees);
         uint64 ticketId = factoryFacet.ticketCount();
 
-        (uint256 ticketFee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.ETH);
+        (uint256 ticketFee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.NATIVE);
 
         uint256 ownerBalBefore = owner.balance;
         uint256 contractBalBefore = hostIt.balance;
 
         hoax(alice, totalFee);
-        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.ETH, alice);
+        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.NATIVE, alice);
 
         assertEq(owner.balance - ownerBalBefore, ticketFee);
         assertEq(hostIt.balance - contractBalBefore, hostItFee);
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), hostItFee);
-        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.ETH), 0);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), hostItFee);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.NATIVE), 0);
         assertEq(alice.balance, 0);
     }
 
@@ -810,24 +806,24 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
 
         TicketData memory td = _getRefundablePaidTicketData();
         FeeType[] memory feeTypes = new FeeType[](1);
-        feeTypes[0] = FeeType.ETH;
+        feeTypes[0] = FeeType.NATIVE;
         uint256[] memory fees = new uint256[](1);
         fees[0] = fee;
         factoryFacet.createTicket(td, feeTypes, fees);
         uint64 ticketId = factoryFacet.ticketCount();
 
-        (uint256 ticketFee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.ETH);
+        (uint256 ticketFee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.NATIVE);
 
         uint256 ownerBalBefore = owner.balance;
         uint256 contractBalBefore = hostIt.balance;
 
         hoax(alice, totalFee);
-        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.ETH, alice);
+        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.NATIVE, alice);
 
         assertEq(owner.balance, ownerBalBefore);
         assertEq(hostIt.balance - contractBalBefore, ticketFee + hostItFee);
-        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.ETH), ticketFee);
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), hostItFee);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.NATIVE), ticketFee);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), hostItFee);
     }
 
     function testFuzz_refundable_ETH_claimWithinWindow(uint256 warpOffset) public {
@@ -843,11 +839,11 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         vm.warp(ftd.endTime + warpOffset);
 
         vm.prank(alice);
-        marketplaceFacet.claimRefund(ticketId, FeeType.ETH, tokenId, bob);
+        marketplaceFacet.claimRefund(ticketId, FeeType.NATIVE, tokenId, bob);
 
         assertEq(bob.balance, fee);
-        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.ETH), 0);
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), hostItFee);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.NATIVE), 0);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), hostItFee);
     }
 
     function testFuzz_refundable_ETH_claimRevertsBeforeEndTime(uint256 warpTo) public {
@@ -863,7 +859,7 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
 
         vm.prank(alice);
         vm.expectRevert(RefundPeriodNotReached.selector);
-        marketplaceFacet.claimRefund(ticketId, FeeType.ETH, tokenId, bob);
+        marketplaceFacet.claimRefund(ticketId, FeeType.NATIVE, tokenId, bob);
     }
 
     function testFuzz_refundable_ETH_claimRevertsAfterWindow(uint256 extraTime) public {
@@ -880,7 +876,7 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
 
         vm.prank(alice);
         vm.expectRevert(RefundPeriodExpired.selector);
-        marketplaceFacet.claimRefund(ticketId, FeeType.ETH, tokenId, bob);
+        marketplaceFacet.claimRefund(ticketId, FeeType.NATIVE, tokenId, bob);
     }
 
     function testFuzz_refundable_ETH_withdrawAfterRefundPeriod(uint256 extraTime) public {
@@ -891,9 +887,9 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         extraTime = bound(extraTime, 0, 365 days);
         vm.warp(ftd.endTime + refundPeriod + extraTime);
 
-        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.ETH, withdrawer);
+        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.NATIVE, withdrawer);
         assertEq(withdrawer.balance, fee);
-        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.ETH), 0);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.NATIVE), 0);
     }
 
     function testFuzz_refundable_ETH_withdrawRevertsBeforeRefundPeriod(uint256 warpTo) public {
@@ -905,7 +901,7 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         vm.warp(warpTo);
 
         vm.expectRevert(WithdrawPeriodNotReached.selector);
-        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.ETH, withdrawer);
+        marketplaceFacet.withdrawTicketBalance(ticketId, FeeType.NATIVE, withdrawer);
     }
 
     function testFuzz_directPayment_ETH_multipleBuyersAccumulate(uint8 buyerCount) public {
@@ -913,17 +909,17 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
 
         _createPaidTicket();
         uint64 ticketId = factoryFacet.ticketCount();
-        (uint256 ticketFee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.ETH);
+        (uint256 ticketFee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.NATIVE);
 
         uint256 ownerBalBefore = owner.balance;
 
         for (uint8 i; i < buyerCount; ++i) {
             address buyer = makeAddr(string(abi.encodePacked("buyer", i)));
             hoax(buyer, totalFee);
-            marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.ETH, buyer);
+            marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.NATIVE, buyer);
         }
 
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), hostItFee * buyerCount);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), hostItFee * buyerCount);
         assertEq(owner.balance - ownerBalBefore, ticketFee * buyerCount);
 
         FullTicketData memory ftd = factoryFacet.ticketData(ticketId);
@@ -933,14 +929,14 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
     function testFuzz_directPayment_ETH_revertsInsufficientValue(uint256 underpay) public {
         _createPaidTicket();
         uint64 ticketId = factoryFacet.ticketCount();
-        (,, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.ETH);
+        (,, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.NATIVE);
 
         underpay = bound(underpay, 1, totalFee);
         uint256 sent = totalFee - underpay;
 
         hoax(alice, totalFee);
-        vm.expectRevert(abi.encodeWithSelector(InsufficientPayment.selector, FeeType.ETH, totalFee));
-        marketplaceFacet.mintTicket{value: sent}(ticketId, FeeType.ETH, alice);
+        vm.expectRevert(abi.encodeWithSelector(InsufficientPayment.selector, FeeType.NATIVE, totalFee));
+        marketplaceFacet.mintTicket{value: sent}(ticketId, FeeType.NATIVE, alice);
     }
 
     function testFuzz_withdrawHostItBalance_ETH(uint256 fee) public {
@@ -949,20 +945,20 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
 
         TicketData memory td = _getPaidTicketData();
         FeeType[] memory feeTypes = new FeeType[](1);
-        feeTypes[0] = FeeType.ETH;
+        feeTypes[0] = FeeType.NATIVE;
         uint256[] memory fees = new uint256[](1);
         fees[0] = fee;
         factoryFacet.createTicket(td, feeTypes, fees);
         uint64 ticketId = factoryFacet.ticketCount();
 
-        (, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.ETH);
+        (, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.NATIVE);
 
         hoax(alice, totalFee);
-        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.ETH, alice);
+        marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.NATIVE, alice);
 
-        marketplaceFacet.withdrawHostItBalance(FeeType.ETH, withdrawer);
+        marketplaceFacet.withdrawHostItBalance(FeeType.NATIVE, withdrawer);
         assertEq(withdrawer.balance, hostItFee);
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), 0);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), 0);
     }
 
     function testFuzz_refundable_ETH_fullLifecycle(uint256 fee, uint256 refundOffset) public {
@@ -972,30 +968,30 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
 
         TicketData memory td = _getRefundablePaidTicketData();
         FeeType[] memory feeTypes = new FeeType[](1);
-        feeTypes[0] = FeeType.ETH;
+        feeTypes[0] = FeeType.NATIVE;
         uint256[] memory fees = new uint256[](1);
         fees[0] = fee;
         factoryFacet.createTicket(td, feeTypes, fees);
         uint64 ticketId = factoryFacet.ticketCount();
 
-        (uint256 ticketFee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.ETH);
+        (uint256 ticketFee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.NATIVE);
         FullTicketData memory ftd = factoryFacet.ticketData(ticketId);
         ITicket ticket = ITicket(ftd.ticketAddress);
 
         hoax(alice, totalFee);
-        uint40 tokenId = marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.ETH, alice);
-        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.ETH), ticketFee);
+        uint40 tokenId = marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.NATIVE, alice);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.NATIVE), ticketFee);
 
         vm.prank(alice);
         ticket.approve(hostIt, tokenId);
         vm.warp(ftd.endTime + refundOffset);
 
         vm.prank(alice);
-        marketplaceFacet.claimRefund(ticketId, FeeType.ETH, tokenId, bob);
+        marketplaceFacet.claimRefund(ticketId, FeeType.NATIVE, tokenId, bob);
 
         assertEq(bob.balance, ticketFee);
-        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.ETH), 0);
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), hostItFee);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.NATIVE), 0);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), hostItFee);
         assertEq(ticket.ownerOf(tokenId), owner);
     }
 
@@ -1005,13 +1001,13 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
 
         TicketData memory td = _getRefundablePaidTicketData();
         FeeType[] memory feeTypes = new FeeType[](1);
-        feeTypes[0] = FeeType.ETH;
+        feeTypes[0] = FeeType.NATIVE;
         uint256[] memory fees = new uint256[](1);
         fees[0] = ETH_FEE;
         factoryFacet.createTicket(td, feeTypes, fees);
         uint64 ticketId = factoryFacet.ticketCount();
 
-        (uint256 ticketFee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.ETH);
+        (uint256 ticketFee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId, FeeType.NATIVE);
         FullTicketData memory ftd = factoryFacet.ticketData(ticketId);
         ITicket ticket = ITicket(ftd.ticketAddress);
 
@@ -1020,10 +1016,10 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
         for (uint8 i; i < buyerCount; ++i) {
             buyers[i] = makeAddr(string(abi.encodePacked("rbuyer", i)));
             hoax(buyers[i], totalFee);
-            tokenIds[i] = marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.ETH, buyers[i]);
+            tokenIds[i] = marketplaceFacet.mintTicket{value: totalFee}(ticketId, FeeType.NATIVE, buyers[i]);
         }
 
-        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.ETH), ticketFee * buyerCount);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.NATIVE), ticketFee * buyerCount);
 
         vm.warp(ftd.endTime);
 
@@ -1031,12 +1027,12 @@ contract MarketplaceTest is DeployedHostItTickets, ERC721Holder {
             vm.prank(buyers[i]);
             ticket.approve(hostIt, tokenIds[i]);
             vm.prank(buyers[i]);
-            marketplaceFacet.claimRefund(ticketId, FeeType.ETH, tokenIds[i], buyers[i]);
+            marketplaceFacet.claimRefund(ticketId, FeeType.NATIVE, tokenIds[i], buyers[i]);
         }
 
         uint256 remaining = uint256(buyerCount - refundCount) * ticketFee;
-        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.ETH), remaining);
-        assertEq(marketplaceFacet.getHostItBalance(FeeType.ETH), hostItFee * buyerCount);
+        assertEq(marketplaceFacet.getTicketBalance(ticketId, FeeType.NATIVE), remaining);
+        assertEq(marketplaceFacet.getHostItBalance(FeeType.NATIVE), hostItFee * buyerCount);
     }
 
     receive() external payable {}

--- a/test/Ticket.t.sol
+++ b/test/Ticket.t.sol
@@ -7,7 +7,6 @@ import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
-import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {ITicket} from "@ticket/interfaces/ITicket.sol";
 import {Ticket} from "@ticket/libs/Ticket.sol";
@@ -72,21 +71,6 @@ contract TicketTest is Test {
         assertEq(ticketClone.balanceOf(alice), 1);
     }
 
-    function test_pause() public {
-        vm.expectEmit(true, true, true, true);
-        emit Pausable.Paused(owner);
-        ticketClone.pause();
-        assertTrue(ticketClone.paused());
-    }
-
-    function test_unpause() public {
-        ticketClone.pause();
-        vm.expectEmit(true, true, true, true);
-        emit Pausable.Unpaused(owner);
-        ticketClone.unpause();
-        assertFalse(ticketClone.paused());
-    }
-
     /// forge-lint: disable-next-item(erc20-unchecked-transfer)
     function test_transferFrom() public {
         uint256 tokenId = ticketClone.mint(alice);
@@ -113,33 +97,51 @@ contract TicketTest is Test {
         assertEq(ticketClone.tokenURI(tokenId), ticketClone.baseURI());
     }
 
-    function test_mintWhilePaused() public {
-        vm.expectEmit(true, true, true, true);
-        emit Pausable.Paused(owner);
-        ticketClone.pause();
-        vm.expectEmit(true, true, true, true);
-        emit IERC721.Transfer(address(0), alice, 1);
+    // ======================================================================
+    //                        USE-TICKET LIFECYCLE
+    // ======================================================================
+
+    function test_useTicket() public {
         uint256 tokenId = ticketClone.mint(alice);
-        assertEq(ticketClone.totalSupply(), tokenId);
-        assertEq(ticketClone.ownerOf(tokenId), alice);
-        assertEq(ticketClone.balanceOf(alice), 1);
+        assertFalse(ticketClone.isUsed(tokenId));
+        vm.expectEmit(true, true, true, true);
+        emit ITicket.TicketUsed(tokenId);
+        ticketClone.useTicket(tokenId);
+        assertTrue(ticketClone.isUsed(tokenId));
+    }
+
+    function test_useTicket_revertsNonexistentToken() public {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721NonexistentToken.selector, uint256(999)));
+        ticketClone.useTicket(999);
+    }
+
+    function test_useTicket_revertsNonOwner() public {
+        uint256 tokenId = ticketClone.mint(alice);
+        vm.prank(alice);
+        vm.expectRevert();
+        ticketClone.useTicket(tokenId);
     }
 
     /// forge-lint: disable-next-item(erc20-unchecked-transfer)
-    function test_revertTransferFromWhilePaused() public {
-        ticketClone.pause();
+    function test_transferFrom_revertsAfterUse() public {
         uint256 tokenId = ticketClone.mint(alice);
+        ticketClone.useTicket(tokenId);
         vm.prank(alice);
-        vm.expectRevert();
-        ticketClone.transferFrom(alice, owner, tokenId);
+        vm.expectRevert(ITicket.TicketAlreadyUsed.selector);
+        ticketClone.transferFrom(alice, bob, tokenId);
     }
 
-    function test_revertSafeTransferFromWhilePaused() public {
-        ticketClone.pause();
+    function test_safeTransferFrom_revertsAfterUse() public {
         uint256 tokenId = ticketClone.mint(alice);
+        ticketClone.useTicket(tokenId);
         vm.prank(alice);
-        vm.expectRevert();
+        vm.expectRevert(ITicket.TicketAlreadyUsed.selector);
         ticketClone.safeTransferFrom(alice, bob, tokenId);
+    }
+
+    function test_isUsed_falseBeforeUse() public {
+        uint256 tokenId = ticketClone.mint(alice);
+        assertFalse(ticketClone.isUsed(tokenId));
     }
 
     function test_otherClonesDontClash() public {
@@ -206,19 +208,6 @@ contract TicketTest is Test {
         vm.prank(alice);
         vm.expectRevert();
         ticketClone.mint(alice);
-    }
-
-    function test_pauseRevertsNonOwner() public {
-        vm.prank(alice);
-        vm.expectRevert();
-        ticketClone.pause();
-    }
-
-    function test_unpauseRevertsNonOwner() public {
-        ticketClone.pause();
-        vm.prank(alice);
-        vm.expectRevert();
-        ticketClone.unpause();
     }
 
     function test_updateNameRevertsNonOwner() public {
@@ -292,5 +281,14 @@ contract TicketTest is Test {
         assertEq(ticketClone.ownerOf(tokenId), to);
         assertEq(ticketClone.balanceOf(to), 1);
         assertEq(ticketClone.balanceOf(alice), 0);
+    }
+
+    function testFuzz_useTicket_blocksTransfer(address to) public {
+        vm.assume(to != address(0) && to.code.length == 0 && to != alice);
+        uint256 tokenId = ticketClone.mint(alice);
+        ticketClone.useTicket(tokenId);
+        vm.prank(alice);
+        vm.expectRevert(ITicket.TicketAlreadyUsed.selector);
+        ticketClone.safeTransferFrom(alice, to, tokenId);
     }
 }

--- a/test/states/DeployedHostItTickets.sol
+++ b/test/states/DeployedHostItTickets.sol
@@ -93,11 +93,11 @@ abstract contract DeployedHostItTickets is Test, DeployHostItTicketsHelper {
     function _mintTicketETH() internal returns (uint64 ticketId_, uint40 tokenId_, uint256 fee_, uint256 hostItFee_) {
         _createPaidTicket();
         ticketId_ = factoryFacet.ticketCount();
-        (uint256 fee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId_, FeeType.ETH);
+        (uint256 fee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId_, FeeType.NATIVE);
         hoax(alice, totalFee);
         vm.expectEmit(true, true, true, true, hostIt);
-        emit TicketMinted(ticketId_, FeeType.ETH, totalFee, 1);
-        tokenId_ = marketplaceFacet.mintTicket{value: totalFee}(ticketId_, FeeType.ETH, alice);
+        emit TicketMinted(ticketId_, FeeType.NATIVE, totalFee, 1);
+        tokenId_ = marketplaceFacet.mintTicket{value: totalFee}(ticketId_, FeeType.NATIVE, alice);
         fee_ = fee;
         hostItFee_ = hostItFee;
     }
@@ -149,11 +149,11 @@ abstract contract DeployedHostItTickets is Test, DeployHostItTicketsHelper {
     {
         _createRefundablePaidTicket();
         ticketId_ = factoryFacet.ticketCount();
-        (uint256 fee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId_, FeeType.ETH);
+        (uint256 fee, uint256 hostItFee, uint256 totalFee) = marketplaceFacet.getAllFees(ticketId_, FeeType.NATIVE);
         hoax(alice, totalFee);
         vm.expectEmit(true, true, true, true, hostIt);
-        emit TicketMinted(ticketId_, FeeType.ETH, totalFee, 1);
-        tokenId_ = marketplaceFacet.mintTicket{value: totalFee}(ticketId_, FeeType.ETH, alice);
+        emit TicketMinted(ticketId_, FeeType.NATIVE, totalFee, 1);
+        tokenId_ = marketplaceFacet.mintTicket{value: totalFee}(ticketId_, FeeType.NATIVE, alice);
         fee_ = fee;
         hostItFee_ = hostItFee;
     }
@@ -221,10 +221,10 @@ abstract contract DeployedHostItTickets is Test, DeployHostItTicketsHelper {
     function _getFreeTicketData() internal view returns (TicketData memory ticketData_) {
         ticketData_ = TicketData({
             startTime: uint40(block.timestamp + 1 days),
-            endTime: uint40(block.timestamp + 2 days),
+            endTime: uint40(block.timestamp + 4 days),
             purchaseStartTime: _currentTime,
             maxTickets: type(uint40).max,
-            maxTicketsPerUser: 0,
+            maxTicketsPerUser: 1,
             isFree: true,
             isRefundable: false,
             name: "Free Ticket",
@@ -236,7 +236,7 @@ abstract contract DeployedHostItTickets is Test, DeployHostItTicketsHelper {
     function _getFreeUpdatedTicketData() internal view returns (TicketData memory ticketData_) {
         ticketData_ = TicketData({
             startTime: uint40(block.timestamp + 1 days),
-            endTime: uint40(block.timestamp + 2 days),
+            endTime: uint40(block.timestamp + 4 days),
             purchaseStartTime: _currentTime,
             maxTickets: 100,
             maxTicketsPerUser: 1,
@@ -254,7 +254,7 @@ abstract contract DeployedHostItTickets is Test, DeployHostItTicketsHelper {
             endTime: uint40(block.timestamp + 2 days),
             purchaseStartTime: _currentTime,
             maxTickets: type(uint40).max,
-            maxTicketsPerUser: 0,
+            maxTicketsPerUser: 1,
             isFree: false,
             isRefundable: false,
             name: "Paid Ticket",
@@ -269,7 +269,7 @@ abstract contract DeployedHostItTickets is Test, DeployHostItTicketsHelper {
             endTime: uint40(block.timestamp + 2 days),
             purchaseStartTime: _currentTime,
             maxTickets: type(uint40).max,
-            maxTicketsPerUser: 0,
+            maxTicketsPerUser: 1,
             isFree: false,
             isRefundable: true,
             name: "Refundable Paid Ticket",
@@ -284,7 +284,7 @@ abstract contract DeployedHostItTickets is Test, DeployHostItTicketsHelper {
             endTime: uint40(block.timestamp + 2 days),
             purchaseStartTime: _currentTime,
             maxTickets: type(uint40).max,
-            maxTicketsPerUser: 0,
+            maxTicketsPerUser: 1,
             isFree: false,
             isRefundable: false,
             name: "Updated Paid Ticket",
@@ -303,7 +303,7 @@ abstract contract DeployedHostItTickets is Test, DeployHostItTicketsHelper {
 
     function _getFeeTypes() internal pure returns (FeeType[] memory feeTypes_) {
         feeTypes_ = new FeeType[](3);
-        feeTypes_[0] = FeeType.ETH;
+        feeTypes_[0] = FeeType.NATIVE;
         feeTypes_[1] = FeeType.USDT;
         feeTypes_[2] = FeeType.USDC;
     }


### PR DESCRIPTION
## Summary
- add trusted-backend direct fiat ticket minting
- add EIP-712 fiat voucher redemption and batch operations
- add replay protection, fiat accounting, guards, and marketplace tests

## Verification
- `forge test --match-path test/Marketplace.t.sol`
- 124 tests passed